### PR TITLE
Make sure that unneeded queryset methods are not supported in the sync

### DIFF
--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -25,7 +25,7 @@ class CDMSQuerySet(models.QuerySet):
         self._cdms_known_related_objects = {}  # {rel_field_name, {cdms_pk: rel_obj}}
         self._iterable_class = CDMSModelIterable
 
-    def mark_as_cdms_skip(self):
+    def skip_cdms(self):
         self.cdms_skip = True
         return self
 

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -5,6 +5,17 @@ from .query import CDMSQuery, CDMSModelIterable, RefreshQuery, \
     InsertQuery, UpdateQuery
 
 
+def only_with_cdms_skip(func):
+    def wrapper(self, *args, **kwargs):
+        if not self.cdms_skip:
+            raise NotImplementedError(
+                '{method} not implemented yet'.format(method=func.__name__)
+            )
+
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
 class CDMSQuerySet(models.QuerySet):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super(CDMSQuerySet, self).__init__(model=model, query=query, using=using, hints=hints)
@@ -29,14 +40,6 @@ class CDMSQuerySet(models.QuerySet):
     def none(self):
         self.cdms_query.set_empty()
         return super(CDMSQuerySet, self).none()
-
-    def select_for_update(self, *args, **kwargs):
-        """
-        Only supported when explicitly skipping cdms.
-        """
-        if not self.cdms_skip:
-            raise NotImplementedError('select_for_update not implemented yet')
-        return super(CDMSQuerySet, self).select_for_update(*args, **kwargs)
 
     def get(self, *args, **kwargs):
         original_cdms_skip = self.cdms_skip
@@ -138,6 +141,94 @@ class CDMSQuerySet(models.QuerySet):
             query.get_compiler().execute()
 
         return return_val
+
+    @only_with_cdms_skip
+    def annotate(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).annotate(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def reverse(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).reverse(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def select_for_update(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).select_for_update(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def distinct(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).distinct(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def values(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).values(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def values_list(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).values_list(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def select_related(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).select_related(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def prefetch_related(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).prefetch_related(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def extra(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).extra(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def defer(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).defer(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def only(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).only(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def raw(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).raw(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def get_or_create(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).get_or_create(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def update_or_create(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).update_or_create(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def count(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).count(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def in_bulk(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).in_bulk(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def earliest(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).earliest(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def latest(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).latest(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def first(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).first(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def last(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).last(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def aggregate(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).aggregate(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def exists(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).exists(*args, **kwargs)
 
 
 class CDMSManager(models.Manager.from_queryset(CDMSQuerySet)):

--- a/crm-poc/apps/migrator/models.py
+++ b/crm-poc/apps/migrator/models.py
@@ -25,12 +25,12 @@ class CDMSModel(TimeStampedModel):
 
     def _do_insert(self, manager, using, fields, update_pk, raw):
         if self._cdms_skip:
-            manager = manager.mark_as_cdms_skip()
+            manager = manager.skip_cdms()
         return super(CDMSModel, self)._do_insert(manager, using, fields, update_pk, raw)
 
     def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update):
         if self._cdms_skip:
-            base_qs = base_qs.mark_as_cdms_skip()
+            base_qs = base_qs.skip_cdms()
         return super(CDMSModel, self)._do_update(base_qs, using, pk_val, values, update_fields, forced_update)
 
     class Meta:

--- a/crm-poc/apps/migrator/query.py
+++ b/crm-poc/apps/migrator/query.py
@@ -113,7 +113,7 @@ class CDMSRefreshCompiler(CDMSGetCompiler):
         if self.query.local_obj:
             return (self.query.local_obj, False)
 
-        results = self.query.model.objects.mark_as_cdms_skip().filter(cdms_pk=self.query.cdms_pk)
+        results = self.query.model.objects.skip_cdms().filter(cdms_pk=self.query.cdms_pk)
         if results:
             return (results[0], False)
 

--- a/crm-poc/apps/migrator/tests/queries/models.py
+++ b/crm-poc/apps/migrator/tests/queries/models.py
@@ -17,12 +17,17 @@ class SimpleMigrator(BaseCDMSMigrator):
     service = 'Simple'
 
 
+class RelatedObj(models.Model):
+    pass
+
+
 class SimpleObj(CDMSModel):
     name = models.CharField(max_length=250)
     dt_field = models.DateTimeField(null=True)
     int_field = models.IntegerField(null=True)
-    
+
     d_field = models.DateField(null=True)
+    fk_obj = models.ForeignKey(RelatedObj, null=True)
 
     objects = MigratorManager()
     django_objects = models.Manager()

--- a/crm-poc/apps/migrator/tests/queries/test_create.py
+++ b/crm-poc/apps/migrator/tests/queries/test_create.py
@@ -13,9 +13,9 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         obj.name = 'simple obj'
 
         self.assertEqual(obj.cdms_pk, '')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         obj.save()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertNotEqual(obj.cdms_pk, '')
 
         self.assertAPICreateCalled(
@@ -32,9 +32,9 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         obj = SimpleObj()
         obj.name = 'simple obj'
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         self.assertRaises(Exception, obj.save)
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -44,9 +44,9 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         MyObject.objects.create() should create a new obj in local and cdms.
         """
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         obj = SimpleObj.objects.create(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertNotEqual(obj.cdms_pk, '')
 
         self.assertAPICreateCalled(
@@ -60,12 +60,12 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         self.assertRaises(
             Exception,
             SimpleObj.objects.create, name='simple obj'
         )
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -75,7 +75,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         We should support MyObject.objects.bulk_create(obj1, obj2) which should create the objects
         in local and cdms.
         """
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         SimpleObj.objects.bulk_create(
             SimpleObj(name='simple obj1'),
             SimpleObj(name='simple obj2')
@@ -97,7 +97,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         self.assertRaises(
             Exception,
             SimpleObj.objects.bulk_create, [
@@ -105,7 +105,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
                 SimpleObj(name='simple obj2')
             ]
         )
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -142,9 +142,9 @@ class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         obj.name = 'simple obj'
 
         self.assertEqual(obj.cdms_pk, '')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         obj.save(cdms_skip=True)
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertEqual(obj.cdms_pk, '')
 
         self.assertNoAPICalled()
@@ -153,11 +153,11 @@ class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
 class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_with_create(self):
         """
-        When calling MyObject.objects.mark_as_cdms_skip().create(), changes should only happen in local, not in cdms.
+        When calling MyObject.objects.skip_cdms().create(), changes should only happen in local, not in cdms.
         """
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
+        obj = SimpleObj.objects.skip_cdms().create(name='simple obj')
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertEqual(obj.cdms_pk, '')
 
         self.assertNoAPICalled()
@@ -165,11 +165,11 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     @skip('TODO: to be fixed')
     def test_with_bulk_create(self):
         """
-        We should support MyObject.objects.mark_as_cdms_skip().bulk_create(obj1, obj2) which should create the objects
+        We should support MyObject.objects.skip_cdms().bulk_create(obj1, obj2) which should create the objects
         in local only.
         """
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
-        SimpleObj.objects.mark_as_cdms_skip().bulk_create(
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
+        SimpleObj.objects.skip_cdms().bulk_create(
             SimpleObj(name='simple obj1'),
             SimpleObj(name='simple obj2')
         )

--- a/crm-poc/apps/migrator/tests/queries/test_create.py
+++ b/crm-poc/apps/migrator/tests/queries/test_create.py
@@ -13,9 +13,9 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         obj.name = 'simple obj'
 
         self.assertEqual(obj.cdms_pk, '')
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         obj.save()
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertNotEqual(obj.cdms_pk, '')
 
         self.assertAPICreateCalled(
@@ -32,9 +32,9 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         obj = SimpleObj()
         obj.name = 'simple obj'
 
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         self.assertRaises(Exception, obj.save)
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -44,9 +44,9 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         MyObject.objects.create() should create a new obj in local and cdms.
         """
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         obj = SimpleObj.objects.create(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertNotEqual(obj.cdms_pk, '')
 
         self.assertAPICreateCalled(
@@ -60,12 +60,12 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         self.assertRaises(
             Exception,
             SimpleObj.objects.create, name='simple obj'
         )
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -75,7 +75,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         We should support MyObject.objects.bulk_create(obj1, obj2) which should create the objects
         in local and cdms.
         """
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         SimpleObj.objects.bulk_create(
             SimpleObj(name='simple obj1'),
             SimpleObj(name='simple obj2')
@@ -97,7 +97,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         self.assertRaises(
             Exception,
             SimpleObj.objects.bulk_create, [
@@ -105,7 +105,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
                 SimpleObj(name='simple obj2')
             ]
         )
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
@@ -142,9 +142,9 @@ class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         obj.name = 'simple obj'
 
         self.assertEqual(obj.cdms_pk, '')
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         obj.save(cdms_skip=True)
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertEqual(obj.cdms_pk, '')
 
         self.assertNoAPICalled()
@@ -155,9 +155,9 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         When calling MyObject.objects.mark_as_cdms_skip().create(), changes should only happen in local, not in cdms.
         """
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         obj = SimpleObj.objects.mark_as_cdms_skip().create(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertEqual(obj.cdms_pk, '')
 
         self.assertNoAPICalled()
@@ -168,7 +168,7 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         We should support MyObject.objects.mark_as_cdms_skip().bulk_create(obj1, obj2) which should create the objects
         in local only.
         """
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
         SimpleObj.objects.mark_as_cdms_skip().bulk_create(
             SimpleObj(name='simple obj1'),
             SimpleObj(name='simple obj2')

--- a/crm-poc/apps/migrator/tests/queries/test_delete.py
+++ b/crm-poc/apps/migrator/tests/queries/test_delete.py
@@ -7,7 +7,7 @@ from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 class BaseDeleteTestCase(BaseMockedCDMSApiTestCase):
     def setUp(self):
         super(BaseDeleteTestCase, self).setUp()
-        self.obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
 
@@ -15,9 +15,9 @@ class BaseDeleteTestCase(BaseMockedCDMSApiTestCase):
 class DeleteTestCase(BaseDeleteTestCase):
     @skip('TODO: to be fixed')
     def test_delete_by_queryset(self):
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         SimpleObj.objects.filter(name='name').delete()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPIDeleteCalled(
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
@@ -26,9 +26,9 @@ class DeleteTestCase(BaseDeleteTestCase):
 
     @skip('TODO: to be fixed')
     def test_delete_from_obj(self):
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.obj.delete()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPIDeleteCalled(
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
@@ -45,16 +45,16 @@ class DeleteTestCase(BaseDeleteTestCase):
 
 class DeleteSkipCDMSTestCase(BaseDeleteTestCase):
     def test_delete_by_queryset(self):
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
-        SimpleObj.objects.mark_as_cdms_skip().filter(name='name').delete()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
+        SimpleObj.objects.skip_cdms().filter(name='name').delete()
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertNoAPICalled()
 
     def test_delete_from_obj(self):
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.obj.delete()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertNoAPICalled()
 

--- a/crm-poc/apps/migrator/tests/queries/test_extras.py
+++ b/crm-poc/apps/migrator/tests/queries/test_extras.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from django.db.models import Count
 
 from migrator.tests.queries.models import SimpleObj
@@ -15,11 +13,10 @@ class SingleObjMixin(object):
 
 
 class AnnotateTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.annotate(Count('name'))
+            SimpleObj.objects.annotate, Count('name')
         )
         self.assertNoAPICalled()
 
@@ -29,11 +26,10 @@ class AnnotateTestCase(BaseMockedCDMSApiTestCase):
 
 
 class ReverseTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.reverse()
+            SimpleObj.objects.reverse
         )
         self.assertNoAPICalled()
 
@@ -43,11 +39,10 @@ class ReverseTestCase(BaseMockedCDMSApiTestCase):
 
 
 class DistinctTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.distinct()
+            SimpleObj.objects.distinct
         )
         self.assertNoAPICalled()
 
@@ -57,11 +52,10 @@ class DistinctTestCase(BaseMockedCDMSApiTestCase):
 
 
 class ValuesTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.values()
+            SimpleObj.objects.values
         )
         self.assertNoAPICalled()
 
@@ -71,11 +65,10 @@ class ValuesTestCase(BaseMockedCDMSApiTestCase):
 
 
 class ValuesListTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.values_list()
+            SimpleObj.objects.values_list
         )
         self.assertNoAPICalled()
 
@@ -85,11 +78,10 @@ class ValuesListTestCase(BaseMockedCDMSApiTestCase):
 
 
 class DatesTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.dates('d_field')
+            SimpleObj.objects.dates, 'd_field', 'year'
         )
         self.assertNoAPICalled()
 
@@ -99,11 +91,10 @@ class DatesTestCase(BaseMockedCDMSApiTestCase):
 
 
 class DatetimesTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.datetimes('d_field')
+            SimpleObj.objects.datetimes, 'd_field', 'year'
         )
         self.assertNoAPICalled()
 
@@ -123,22 +114,7 @@ class NoneTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
 
-class AllTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
-    def test(self):
-        self.assertRaises(
-            NotImplementedError,
-            list, SimpleObj.objects.all()
-        )
-        self.assertNoAPICalled()
-
-    def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().all())
-        self.assertNoAPICalled()
-
-
-class SelectRelatedTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
+class SelectRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -146,13 +122,12 @@ class SelectRelatedTestCase(BaseMockedCDMSApiTestCase):
         )
         self.assertNoAPICalled()
 
-    @skip('TODO: should be allowed')
     def test_skip_cdms(self):
-        pass
+        SimpleObj.objects.mark_as_cdms_skip().select_related('fk_obj').get(pk=self.obj.pk)
+        self.assertNoAPICalled()
 
 
-class PrefetchRelatedTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
+class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -160,17 +135,16 @@ class PrefetchRelatedTestCase(BaseMockedCDMSApiTestCase):
         )
         self.assertNoAPICalled()
 
-    @skip('TODO: should be allowed')
     def test_skip_cdms(self):
-        pass
+        SimpleObj.objects.mark_as_cdms_skip().prefetch_related('fk_obj').get(pk=self.obj.pk)
+        self.assertNoAPICalled()
 
 
 class ExtraTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            list, SimpleObj.objects.extra(select={'is_recent': "dt_field > '2006-01-01'"})
+            SimpleObj.objects.extra, select={'is_recent': "dt_field > '2006-01-01'"}
         )
         self.assertNoAPICalled()
 
@@ -180,7 +154,6 @@ class ExtraTestCase(BaseMockedCDMSApiTestCase):
 
 
 class DeferTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -194,7 +167,6 @@ class DeferTestCase(BaseMockedCDMSApiTestCase):
 
 
 class OnlyTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -208,7 +180,6 @@ class OnlyTestCase(BaseMockedCDMSApiTestCase):
 
 
 class RawTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -222,7 +193,6 @@ class RawTestCase(BaseMockedCDMSApiTestCase):
 
 
 class GetOrCreateTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -236,7 +206,6 @@ class GetOrCreateTestCase(BaseMockedCDMSApiTestCase):
 
 
 class UpdateOrCreateTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -250,7 +219,6 @@ class UpdateOrCreateTestCase(BaseMockedCDMSApiTestCase):
 
 
 class CountTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -264,7 +232,6 @@ class CountTestCase(BaseMockedCDMSApiTestCase):
 
 
 class InBulkTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -278,7 +245,6 @@ class InBulkTestCase(BaseMockedCDMSApiTestCase):
 
 
 class LatestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -292,7 +258,6 @@ class LatestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
 
 
 class EarliestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -306,7 +271,6 @@ class EarliestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
 
 
 class FirstTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -320,7 +284,6 @@ class FirstTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
 
 
 class LastTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -334,7 +297,6 @@ class LastTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
 
 
 class AggregateTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,
@@ -348,7 +310,6 @@ class AggregateTestCase(BaseMockedCDMSApiTestCase):
 
 
 class ExistsTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: should raise exception')
     def test(self):
         self.assertRaises(
             NotImplementedError,

--- a/crm-poc/apps/migrator/tests/queries/test_extras.py
+++ b/crm-poc/apps/migrator/tests/queries/test_extras.py
@@ -7,7 +7,7 @@ from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 class SingleObjMixin(object):
     def setUp(self):
         super(SingleObjMixin, self).setUp()
-        self.obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
 
@@ -21,7 +21,7 @@ class AnnotateTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().annotate(Count('name')))
+        list(SimpleObj.objects.skip_cdms().annotate(Count('name')))
         self.assertNoAPICalled()
 
 
@@ -34,7 +34,7 @@ class ReverseTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().reverse())
+        list(SimpleObj.objects.skip_cdms().reverse())
         self.assertNoAPICalled()
 
 
@@ -47,7 +47,7 @@ class DistinctTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().distinct())
+        list(SimpleObj.objects.skip_cdms().distinct())
         self.assertNoAPICalled()
 
 
@@ -60,7 +60,7 @@ class ValuesTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().values())
+        list(SimpleObj.objects.skip_cdms().values())
         self.assertNoAPICalled()
 
 
@@ -73,7 +73,7 @@ class ValuesListTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().values_list())
+        list(SimpleObj.objects.skip_cdms().values_list())
         self.assertNoAPICalled()
 
 
@@ -86,7 +86,7 @@ class DatesTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().dates('d_field', 'year'))
+        list(SimpleObj.objects.skip_cdms().dates('d_field', 'year'))
         self.assertNoAPICalled()
 
 
@@ -99,7 +99,7 @@ class DatetimesTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().datetimes('dt_field', 'year'))
+        list(SimpleObj.objects.skip_cdms().datetimes('dt_field', 'year'))
         self.assertNoAPICalled()
 
 
@@ -110,7 +110,7 @@ class NoneTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().none())
+        list(SimpleObj.objects.skip_cdms().none())
         self.assertNoAPICalled()
 
 
@@ -123,7 +123,7 @@ class SelectRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().select_related('fk_obj').get(pk=self.obj.pk)
+        SimpleObj.objects.skip_cdms().select_related('fk_obj').get(pk=self.obj.pk)
         self.assertNoAPICalled()
 
 
@@ -136,7 +136,7 @@ class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().prefetch_related('fk_obj').get(pk=self.obj.pk)
+        SimpleObj.objects.skip_cdms().prefetch_related('fk_obj').get(pk=self.obj.pk)
         self.assertNoAPICalled()
 
 
@@ -149,7 +149,7 @@ class ExtraTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().extra(select={'is_recent': "dt_field > '2006-01-01'"}))
+        list(SimpleObj.objects.skip_cdms().extra(select={'is_recent': "dt_field > '2006-01-01'"}))
         self.assertNoAPICalled()
 
 
@@ -162,7 +162,7 @@ class DeferTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().defer('name'))
+        list(SimpleObj.objects.skip_cdms().defer('name'))
         self.assertNoAPICalled()
 
 
@@ -175,7 +175,7 @@ class OnlyTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().only('name'))
+        list(SimpleObj.objects.skip_cdms().only('name'))
         self.assertNoAPICalled()
 
 
@@ -188,7 +188,7 @@ class RawTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().raw('select * from queries_simpleobj'))
+        list(SimpleObj.objects.skip_cdms().raw('select * from queries_simpleobj'))
         self.assertNoAPICalled()
 
 
@@ -201,7 +201,7 @@ class GetOrCreateTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().get_or_create(name='name', defaults={'int_field': 1})
+        SimpleObj.objects.skip_cdms().get_or_create(name='name', defaults={'int_field': 1})
         self.assertNoAPICalled()
 
 
@@ -214,7 +214,7 @@ class UpdateOrCreateTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().update_or_create(name='name', defaults={'int_field': 1})
+        SimpleObj.objects.skip_cdms().update_or_create(name='name', defaults={'int_field': 1})
         self.assertNoAPICalled()
 
 
@@ -227,7 +227,7 @@ class CountTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().count()
+        SimpleObj.objects.skip_cdms().count()
         self.assertNoAPICalled()
 
 
@@ -240,7 +240,7 @@ class InBulkTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().in_bulk([1, 2])
+        SimpleObj.objects.skip_cdms().in_bulk([1, 2])
         self.assertNoAPICalled()
 
 
@@ -253,7 +253,7 @@ class LatestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().latest('dt_field')
+        SimpleObj.objects.skip_cdms().latest('dt_field')
         self.assertNoAPICalled()
 
 
@@ -266,7 +266,7 @@ class EarliestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().earliest('dt_field')
+        SimpleObj.objects.skip_cdms().earliest('dt_field')
         self.assertNoAPICalled()
 
 
@@ -279,7 +279,7 @@ class FirstTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().first()
+        SimpleObj.objects.skip_cdms().first()
         self.assertNoAPICalled()
 
 
@@ -292,7 +292,7 @@ class LastTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().last()
+        SimpleObj.objects.skip_cdms().last()
         self.assertNoAPICalled()
 
 
@@ -305,7 +305,7 @@ class AggregateTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().aggregate(Count('name'))
+        SimpleObj.objects.skip_cdms().aggregate(Count('name'))
         self.assertNoAPICalled()
 
 
@@ -318,5 +318,5 @@ class ExistsTestCase(BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.mark_as_cdms_skip().exists()
+        SimpleObj.objects.skip_cdms().exists()
         self.assertNoAPICalled()

--- a/crm-poc/apps/migrator/tests/queries/test_filter_exclude.py
+++ b/crm-poc/apps/migrator/tests/queries/test_filter_exclude.py
@@ -41,7 +41,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
 
 class FilterSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_filter(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().filter(name='something'))
+        list(SimpleObj.objects.skip_cdms().filter(name='something'))
         self.assertNoAPICalled()
 
 
@@ -78,7 +78,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
 
 class ExcludeSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_exclude(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().exclude(name='something'))
+        list(SimpleObj.objects.skip_cdms().exclude(name='something'))
         self.assertNoAPICalled()
 
 

--- a/crm-poc/apps/migrator/tests/queries/test_filter_lookups.py
+++ b/crm-poc/apps/migrator/tests/queries/test_filter_lookups.py
@@ -10,7 +10,7 @@ from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
     def setUp(self):
         super(FilterLookupsTestCase, self).setUp()
-        self.obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='before something after'
         )
 
@@ -213,7 +213,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
 class ValueLookupsTestCase(BaseMockedCDMSApiTestCase):
     def setUp(self):
         super(ValueLookupsTestCase, self).setUp()
-        self.obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='before something after'
         )
 

--- a/crm-poc/apps/migrator/tests/queries/test_get.py
+++ b/crm-poc/apps/migrator/tests/queries/test_get.py
@@ -51,12 +51,12 @@ class GetTestCase(BaseGetTestCase):
         should hit the cdms api, create a local obj and return it.
         """
         SimpleObj.objects.mark_as_cdms_skip().all().delete()
-        self.assertEqual(SimpleObj.objects.count(), 0)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
 
         cdms_pk = 'cdms-pk'
 
         obj = SimpleObj.objects.get(cdms_pk=cdms_pk)
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertEqual(obj.cdms_pk, cdms_pk)
 
         self.assertAPIGetCalled(

--- a/crm-poc/apps/migrator/tests/queries/test_get.py
+++ b/crm-poc/apps/migrator/tests/queries/test_get.py
@@ -14,7 +14,7 @@ from cdms_api.utils import mocked_cdms_get
 class BaseGetTestCase(BaseMockedCDMSApiTestCase):
     def setUp(self):
         super(BaseGetTestCase, self).setUp()
-        self.obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
 
@@ -50,13 +50,13 @@ class GetTestCase(BaseGetTestCase):
         MyObject.objects.get(cdms_pk=..) when local obj does not exist,
         should hit the cdms api, create a local obj and return it.
         """
-        SimpleObj.objects.mark_as_cdms_skip().all().delete()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 0)
+        SimpleObj.objects.skip_cdms().all().delete()
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         cdms_pk = 'cdms-pk'
 
         obj = SimpleObj.objects.get(cdms_pk=cdms_pk)
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertEqual(obj.cdms_pk, cdms_pk)
 
         self.assertAPIGetCalled(
@@ -171,10 +171,10 @@ class GetTestCase(BaseGetTestCase):
 
 class GetSkipCDMSTestCase(BaseGetTestCase):
     def test_get_by_any_fields_allowed(self):
-        SimpleObj.objects.mark_as_cdms_skip().get(pk=self.obj.pk)
+        SimpleObj.objects.skip_cdms().get(pk=self.obj.pk)
         self.assertNoAPICalled()
 
-        SimpleObj.objects.mark_as_cdms_skip().get(cdms_pk=self.obj.cdms_pk)
+        SimpleObj.objects.skip_cdms().get(cdms_pk=self.obj.cdms_pk)
         self.assertNoAPICalled()
 
 

--- a/crm-poc/apps/migrator/tests/queries/test_order_by.py
+++ b/crm-poc/apps/migrator/tests/queries/test_order_by.py
@@ -20,11 +20,11 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
 
 class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_order_by_one_field(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().order_by('name'))
+        list(SimpleObj.objects.skip_cdms().order_by('name'))
         self.assertNoAPICalled()
 
     def test_order_by_two_fields(self):
-        list(SimpleObj.objects.mark_as_cdms_skip().order_by('name', 'int_field'))
+        list(SimpleObj.objects.skip_cdms().order_by('name', 'int_field'))
         self.assertNoAPICalled()
 
     @skip('TODO: to be fixed')

--- a/crm-poc/apps/migrator/tests/queries/test_update.py
+++ b/crm-poc/apps/migrator/tests/queries/test_update.py
@@ -24,10 +24,10 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         obj.name = 'simple obj'
         obj.save()
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -59,10 +59,10 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         )
 
         # save
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         obj.name = 'new name'
         self.assertRaises(Exception, obj.save)
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         self.assertAPIGetCalled(SimpleObj, kwargs={'guid': 'cdms-pk'})
         self.assertAPINotCalled(['create', 'list', 'delete'])
@@ -89,9 +89,9 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         SimpleObj.objects.filter(pk=obj.pk).update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -124,9 +124,9 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk', name='old name')
         SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk2', name='old name 2')
 
-        self.assertEqual(SimpleObj.objects.count(), 2)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
         SimpleObj.objects.filter(name__icontains='name').update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 2)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -165,13 +165,13 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         self.assertRaises(
             Exception,
             SimpleObj.objects.filter(pk=obj.pk).update,
             name='simple obj'
         )
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         self.assertAPIGetCalled(SimpleObj, kwargs={'guid': 'cdms-pk'})
         self.assertAPINotCalled(['create', 'list', 'delete'])
@@ -215,10 +215,10 @@ class UpdateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         obj.name = 'simple obj'
         obj.save(cdms_skip=True)
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         self.assertNoAPICalled()
 
@@ -235,9 +235,9 @@ class UpdateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
         SimpleObj.objects.mark_as_cdms_skip().filter(pk=obj.pk).update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 1)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
 
         self.assertNoAPICalled()
 
@@ -249,9 +249,9 @@ class UpdateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         obj1 = SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk', name='old name')
         obj2 = SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk2', name='old name 2')
 
-        self.assertEqual(SimpleObj.objects.count(), 2)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
         SimpleObj.objects.mark_as_cdms_skip().filter(name__icontains='name').update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.count(), 2)
+        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
 
         self.assertNoAPICalled()
 

--- a/crm-poc/apps/migrator/tests/queries/test_update.py
+++ b/crm-poc/apps/migrator/tests/queries/test_update.py
@@ -19,15 +19,15 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(modified_on=modified_on)
 
         # create without cdms and then save
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         obj.name = 'simple obj'
         obj.save()
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -53,22 +53,22 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         # set up
         self.mocked_cdms_api.update.side_effect = Exception
 
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
         # save
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         obj.name = 'new name'
         self.assertRaises(Exception, obj.save)
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertAPIGetCalled(SimpleObj, kwargs={'guid': 'cdms-pk'})
         self.assertAPINotCalled(['create', 'list', 'delete'])
 
         # check that the obj in the db didn't change
-        obj = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj.pk)
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
         self.assertEqual(obj.name, 'old name')
 
 
@@ -84,14 +84,14 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(modified_on=modified_on)
 
         # create without cdms and then save
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         SimpleObj.objects.filter(pk=obj.pk).update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -121,12 +121,12 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(modified_on=modified_on)
 
         # create without cdms and then save
-        SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk', name='old name')
-        SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk2', name='old name 2')
+        SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk', name='old name')
+        SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk2', name='old name 2')
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 2)
         SimpleObj.objects.filter(name__icontains='name').update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 2)
 
         # check cdms get called
         self.assertAPIGetCalled(
@@ -160,24 +160,24 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         """
         self.mocked_cdms_api.update.side_effect = Exception
 
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertRaises(
             Exception,
             SimpleObj.objects.filter(pk=obj.pk).update,
             name='simple obj'
         )
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertAPIGetCalled(SimpleObj, kwargs={'guid': 'cdms-pk'})
         self.assertAPINotCalled(['create', 'list', 'delete'])
 
         # check that the obj in the db didn't change
-        obj = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj.pk)
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
         self.assertEqual(obj.name, 'old name')
 
 
@@ -210,55 +210,55 @@ class UpdateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         obj.save(cdms_skip=True) should only update the obj in local.
         """
         # create without cdms and then save
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         obj.name = 'simple obj'
         obj.save(cdms_skip=True)
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertNoAPICalled()
 
         # check that the obj in the db changed
-        obj = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj.pk)
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
         self.assertEqual(obj.name, 'simple obj')
 
 
 class UpdateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_update_single_obj(self):
         # create without cdms and then save
-        obj = SimpleObj.objects.mark_as_cdms_skip().create(
+        obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
-        SimpleObj.objects.mark_as_cdms_skip().filter(pk=obj.pk).update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 1)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
+        SimpleObj.objects.skip_cdms().filter(pk=obj.pk).update(name='simple obj')
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertNoAPICalled()
 
         # check that the obj in the db changed
-        obj = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj.pk)
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
         self.assertEqual(obj.name, 'simple obj')
 
     def test_update_multiple_objs(self):
-        obj1 = SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk', name='old name')
-        obj2 = SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk2', name='old name 2')
+        obj1 = SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk', name='old name')
+        obj2 = SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk2', name='old name 2')
 
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
-        SimpleObj.objects.mark_as_cdms_skip().filter(name__icontains='name').update(name='simple obj')
-        self.assertEqual(SimpleObj.objects.mark_as_cdms_skip().count(), 2)
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 2)
+        SimpleObj.objects.skip_cdms().filter(name__icontains='name').update(name='simple obj')
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 2)
 
         self.assertNoAPICalled()
 
         # check that the objs in the db changed
-        obj1 = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj1.pk)
+        obj1 = SimpleObj.objects.skip_cdms().get(pk=obj1.pk)
         self.assertEqual(obj1.name, 'simple obj')
-        obj2 = SimpleObj.objects.mark_as_cdms_skip().get(pk=obj2.pk)
+        obj2 = SimpleObj.objects.skip_cdms().get(pk=obj2.pk)
         self.assertEqual(obj2.name, 'simple obj')
 
 
@@ -274,12 +274,12 @@ class SelectForUpdateCDMSTestCase(BaseMockedCDMSApiTestCase):
 
     def test_as_usual_with_cdms_skip(self):
         """
-        MyObject.objects.mark_as_cdms_skip().select_for_update() working as usual.
+        MyObject.objects.skip_cdms().select_for_update() working as usual.
         """
-        SimpleObj.objects.mark_as_cdms_skip().create(cdms_pk='cdms-pk', name='old name')
+        SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk', name='old name')
 
         with transaction.atomic():
-            entries = SimpleObj.objects.mark_as_cdms_skip().select_for_update().filter(name__icontains='name')
+            entries = SimpleObj.objects.skip_cdms().select_for_update().filter(name__icontains='name')
             self.assertEqual(len(entries), 1)
 
             self.assertNoAPICalled()


### PR DESCRIPTION
The following queryset methods will only work if explicitly set to skip the cdms sync:

- annotate
- reverse
- select_for_update
- distinct
- values
- values_list
- dates
- datetimes
- select_related
- prefetch_related
- extra
- defer
- only
- raw
- get_or_create
- update_or_create
- count
- in_bulk
- earliest
- latest
- first
- last
- aggregate
- exists