### PR TITLE
Create operations

### DIFF
--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -105,9 +105,8 @@ class CDMSQuerySet(models.QuerySet):
             return
         ops = connections[self.db].ops
         batch_size = (batch_size or max(ops.bulk_batch_size(fields, objs), 1))
-        for batch in [objs[i:i + batch_size]
-                      for i in range(0, len(objs), batch_size)]:
-
+        batches = [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]
+        for batch in batches:
             mngr = self.model._base_manager
             if self.cdms_skip:
                 mngr = mngr.skip_cdms()

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -64,7 +64,7 @@ class CDMSQuerySet(models.QuerySet):
         """
         obj = self.model(**kwargs)
         self._for_write = True
-        obj.save(force_insert=True, using=self.db, cdms_skip=self.cdms_skip)
+        obj.save(force_insert=True, using=self.db, skip_cdms=self.cdms_skip)
         return obj
 
     def _filter_or_exclude(self, negate, *args, **kwargs):

--- a/crm-poc/apps/migrator/models.py
+++ b/crm-poc/apps/migrator/models.py
@@ -15,7 +15,7 @@ class CDMSModel(TimeStampedModel):
     def save(self, *args, **kwargs):
         # a bit hacky but it makes things work :-P
         original_cdms_skip = self._cdms_skip
-        self._cdms_skip = kwargs.pop('cdms_skip', False)
+        self._cdms_skip = kwargs.pop('skip_cdms', False)
         try:
             ret = super(CDMSModel, self).save(*args, **kwargs)
         finally:

--- a/crm-poc/apps/migrator/query.py
+++ b/crm-poc/apps/migrator/query.py
@@ -136,7 +136,7 @@ class CDMSRefreshCompiler(CDMSGetCompiler):
                 obj, cdms_data,
                 cdms_known_related_objects=self.query.cdms_known_related_objects
             )
-            obj.save(cdms_skip=True)
+            obj.save(skip_cdms=True)
 
             # 2nd save for the modified/created field (this can be improved)
             update_fields = {}

--- a/crm-poc/apps/migrator/tests/queries/base.py
+++ b/crm-poc/apps/migrator/tests/queries/base.py
@@ -24,7 +24,7 @@ class BaseMockedCDMSApiTestCase(TransactionTestCase):
 
             _args, _kwargs = mock_verb.call_args_list[index]
             self.assertEqual(_args, (model.cdms_migrator.service,))
-            self.assertListEqual(list(_kwargs.keys()), list(single_kwargs.keys()))
+            self.assertEqual(set(_kwargs.keys()), set(single_kwargs.keys()))
 
             for key, value in _kwargs.items():
                 single_value = single_kwargs[key]

--- a/crm-poc/apps/migrator/tests/queries/test_create.py
+++ b/crm-poc/apps/migrator/tests/queries/test_create.py
@@ -86,14 +86,14 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
 class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_success(self):
         """
-        When calling obj.save(cdms_skip=True), changes should only happen in local, not in cdms.
+        When calling obj.save(skip_cdms=True), changes should only happen in local, not in cdms.
         """
         obj = SimpleObj()
         obj.name = 'simple obj'
 
         self.assertEqual(obj.cdms_pk, '')
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
-        obj.save(cdms_skip=True)
+        obj.save(skip_cdms=True)
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         self.assertEqual(obj.cdms_pk, '')
 

--- a/crm-poc/apps/migrator/tests/queries/test_create.py
+++ b/crm-poc/apps/migrator/tests/queries/test_create.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from migrator.tests.queries.models import SimpleObj
 from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 
@@ -25,7 +23,7 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
 
     def test_exception_triggers_rollback(self):
         """
-        In case of exceptions during obj.save(), no changes should be reflected in the db.
+        In case of exceptions during cdms calls, no changes should be reflected in the db.
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
@@ -56,7 +54,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
 
     def test_exception_triggers_rollback(self):
         """
-        In case of exceptions during MyObject.objects.create(), no changes should be reflected in the db.
+        In case of exceptions during cdms calls, no changes should be reflected in the db.
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
@@ -69,68 +67,20 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 
-    @skip('TODO: to be fixed')
     def test_with_bulk_create(self):
         """
-        We should support MyObject.objects.bulk_create(obj1, obj2) which should create the objects
-        in local and cdms.
+        bulk_create() not currently implemented.
         """
-        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
-        SimpleObj.objects.bulk_create(
-            SimpleObj(name='simple obj1'),
-            SimpleObj(name='simple obj2')
-        )
-        self.assertAPICreateCalled(
-            SimpleObj,
-            data=[
-                {'data': {'Name': 'simple obj1'}},
-                {'data': {'Name': 'simple obj2'}}
-            ],
-            tot=2
-        )
-        self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
-
-    @skip('TODO: to be fixed')
-    def test_exception_triggers_rollback_with_bulk_create(self):
-        """
-        If we decide to support bulk_create, exceptions in cdms calls should rollback the changes.
-        """
-        self.mocked_cdms_api.create.side_effect = Exception
-
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         self.assertRaises(
-            Exception,
-            SimpleObj.objects.bulk_create, [
-                SimpleObj(name='simple obj'),
+            NotImplementedError,
+            SimpleObj.objects.bulk_create,
+            [
+                SimpleObj(name='simple obj1'),
                 SimpleObj(name='simple obj2')
             ]
         )
-        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
-
-        self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
-
-
-class CreateWithExtraManagerTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: to be decided')
-    def test_success(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
-
-    @skip('TODO: to be decided')
-    def test_exception_triggers_rollback(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
-
-    @skip('TODO: to be decided')
-    def test_exception_triggers_rollback_with_bulk_create(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
+        self.assertNoAPICalled()
 
 
 class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
@@ -162,16 +112,15 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertNoAPICalled()
 
-    @skip('TODO: to be fixed')
     def test_with_bulk_create(self):
         """
-        We should support MyObject.objects.skip_cdms().bulk_create(obj1, obj2) which should create the objects
-        in local only.
+        When calling MyObject.objects.skip_cdms().bulk_create(obj1, obj2), changes should only happen in local,
+        not in cdms.
         """
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
-        SimpleObj.objects.skip_cdms().bulk_create(
+        SimpleObj.objects.skip_cdms().bulk_create([
             SimpleObj(name='simple obj1'),
             SimpleObj(name='simple obj2')
-        )
+        ])
 
         self.assertNoAPICalled()

--- a/crm-poc/apps/migrator/tests/queries/test_get.py
+++ b/crm-poc/apps/migrator/tests/queries/test_get.py
@@ -150,7 +150,7 @@ class GetTestCase(BaseGetTestCase):
         If for some reasons cdms_pk is blank, the cdms api call shouldn't happen.
         """
         self.obj.cdms_pk = ''
-        self.obj.save(cdms_skip=True)
+        self.obj.save(skip_cdms=True)
 
         SimpleObj.objects.get(pk=self.obj.pk)
 

--- a/crm-poc/apps/migrator/tests/queries/test_update.py
+++ b/crm-poc/apps/migrator/tests/queries/test_update.py
@@ -207,7 +207,7 @@ class UpdateWithExtraManagerTestCase(BaseMockedCDMSApiTestCase):
 class UpdateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_save(self):
         """
-        obj.save(cdms_skip=True) should only update the obj in local.
+        obj.save(skip_cdms=True) should only update the obj in local.
         """
         # create without cdms and then save
         obj = SimpleObj.objects.skip_cdms().create(
@@ -217,7 +217,7 @@ class UpdateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         obj.name = 'simple obj'
-        obj.save(cdms_skip=True)
+        obj.save(skip_cdms=True)
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertNoAPICalled()


### PR DESCRIPTION
Ops which trigger cdms sync:
- `obj.save()`
- `Clazz.objects.create()`

Currently not implemented:
- `Clazz.objects.bulk_create()`

Skipping cmds sync supported with:
- `obj.save(skip_skip=True)`
- `Clazz.objects.skip_cdms().create()`
- `Clazz.objects.skip_cdms().bulk_create()`


Using an extra custom manager (e.g. `Clazz.extra_manager....`) at the moment give unexpected results.