### PR TITLE
Make sure update operations are covered

### DIFF
--- a/crm-poc/apps/migrator/cdms_migrator.py
+++ b/crm-poc/apps/migrator/cdms_migrator.py
@@ -37,13 +37,12 @@ class BaseCDMSMigrator(object):
 
     def update_cdms_data_from_local(self, local_obj, cdms_data):
         values = [
-            (field, getattr(local_obj, field.name)) for field in local_obj._meta.fields
+            (field.name, getattr(local_obj, field.name)) for field in local_obj._meta.fields
         ]
         return self.update_cdms_data_from_values(values, cdms_data)
 
     def update_cdms_data_from_values(self, values, cdms_data):
-        for field, value in values:
-            field_name = field.name
+        for field_name, value in values:
             try:
                 cdms_field, mapping_func, _ = self.get_fields_mapping(field_name)
             except NotMappingFieldException:

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -132,7 +132,7 @@ class CDMSQuerySet(models.QuerySet):
 
             # update cdms_pk local
             obj.cdms_pk = cdms_pk
-            self.filter(pk=return_val).update(cdms_pk=cdms_pk)
+            self._clone().skip_cdms().filter(pk=return_val).update(cdms_pk=cdms_pk)
 
         return return_val
 
@@ -147,13 +147,10 @@ class CDMSQuerySet(models.QuerySet):
                     cdms_pk = value
                 else:
                     model_values.append(
-                        (field, value)
+                        (field.name, value)
                     )
 
-            if not cdms_pk:
-                raise NotImplementedError(
-                    'Cannot update without cdms pk'
-                )
+            assert cdms_pk, 'Cannot update without cdms pk'
 
             query = UpdateQuery(self.model)
             query.add_update_fields(cdms_pk, model_values)
@@ -252,6 +249,10 @@ class CDMSQuerySet(models.QuerySet):
     @only_with_cdms_skip
     def bulk_create(self, *args, **kwargs):
         return super(CDMSQuerySet, self).bulk_create(*args, **kwargs)
+
+    @only_with_cdms_skip
+    def update(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).update(*args, **kwargs)
 
 
 class CDMSManager(models.Manager.from_queryset(CDMSQuerySet)):

--- a/crm-poc/apps/migrator/query.py
+++ b/crm-poc/apps/migrator/query.py
@@ -148,7 +148,7 @@ class CDMSRefreshCompiler(CDMSGetCompiler):
                 obj.cdms_pk = self.query.cdms_pk
                 update_fields['created'] = obj.created
                 update_fields['cdms_pk'] = obj.cdms_pk
-            manager.filter(pk=obj.pk).update(**update_fields)
+            manager.skip_cdms().filter(pk=obj.pk).update(**update_fields)
 
         return obj
 


### PR DESCRIPTION
Ops which trigger cdms sync:
- obj.save()

Currently not implemented:
- Clazz.objects.filter(...).update()
- Clazz.objects.select_for_update()

Skipping cdms sync supported with:
- obj.save(skip_cdms=True)
- Clazz.objects.skip_cdms().filter(...).update()
- Clazz.objects.skip_cdms().select_for_update()

Clazz.objects.filter(...).update() not supported as in case of multiple
cdms update, we can't undo those changes that already happened if an
error occurs.