### PR TITLE
Make sure get operations are covered

### DIFF
--- a/crm-poc/apps/cdms_api/exceptions.py
+++ b/crm-poc/apps/cdms_api/exceptions.py
@@ -5,5 +5,9 @@ class CDMSException(Exception):
         self.status_code = status_code
 
 
+class CDMSNotFoundException(CDMSException):
+    pass
+
+
 class CDMSUnauthorizedException(CDMSException):
     pass


### PR DESCRIPTION
- Clazz.objects.get(id=...)
	- if local obj exists, get cdms obj, compare, update if necessary and return
	- if local obj doesn't exist, raise DoesNotExist
- Clazz.objects.get(cdms_pk=...)
	- if local obj exists, get cdms obj, compare, update if necessary and return
	- if local obj doesn't exist but cdms obj does, get, create local and return
	- if neither local nor cdms obj exists, raise DoesNotExist
- Clazz.objects.get(other_field=...)
	- if returns 1 obj from local, same as get(id=...)
	- if returns >= 2, raise MultipleObjectsReturned
	- if 0, raise DoesNotExist

Re. sync operations:
- if local and cdms obj in sync, get won't update any objs
- if cdms obj more up-to-date, get will update local obj
- if local obj more up-to-date, raise ObjectsNotInSyncException as atm this shouldn't happen

Skipping cdms sync supported with:
- Clazz.objects.skip_cdms().get(...)