### PR TITLE
Delete ops

### DIFF
--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -272,6 +272,10 @@ class CDMSQuerySet(models.QuerySet):
     def update(self, *args, **kwargs):
         return super(CDMSQuerySet, self).update(*args, **kwargs)
 
+    @only_with_cdms_skip
+    def delete(self, *args, **kwargs):
+        return super(CDMSQuerySet, self).delete(*args, **kwargs)
+
 
 class CDMSManager(models.Manager.from_queryset(CDMSQuerySet)):
     pass

--- a/crm-poc/apps/migrator/query.py
+++ b/crm-poc/apps/migrator/query.py
@@ -153,6 +153,14 @@ class CDMSRefreshCompiler(CDMSGetCompiler):
         return obj
 
 
+class CDMSDeleteCompiler(CDMSGetCompiler):
+    def execute(self):
+        return cdms_conn.delete(
+            self.get_service(),
+            guid=self.query.cdms_pk
+        )
+
+
 class CDMSModelIterable(models.query.ModelIterable):
     def __iter__(self):
 
@@ -412,3 +420,7 @@ class RefreshQuery(GetQuery):
             "you can either call set_local_obj or set_cdms_data but not both"
         self.cdms_pk = self.model.cdms_migrator.get_cdms_pk(cdms_data)
         self.cdms_data = cdms_data
+
+
+class DeleteQuery(GetQuery):
+    compiler = CDMSDeleteCompiler


### PR DESCRIPTION
- Clazz.objects.filter(...).delete() not implemented as deleting
multiple cdms objects cannot be atomic
- obj.delete() deletes the local and the cdms obj
- obj.delete(skip_cdms=True) deletes the local obj only