### PR TITLE
Sync modified field using CDMS as source of truth

### DIFF
--- a/crm-poc/apps/cdms_api/base.py
+++ b/crm-poc/apps/cdms_api/base.py
@@ -172,21 +172,16 @@ class CDMSApi(object):
         )
         return self.make_request('get', url)
 
-    def _cleanup_data_before_changes(self, cdms_data):
-        del cdms_data['optevia_LastVerified']
-        del cdms_data['ModifiedOn']
-        del cdms_data['CreatedOn']
-
-        return cdms_data
-
     def update(self, service, guid, data):
         url = "{base_url}/{service}Set(guid'{guid}')".format(
             base_url=self.CRM_REST_BASE_URL,
             service=service,
             guid=guid
         )
-        data = self._cleanup_data_before_changes(data)
-        return self.make_request('put', url, data=data)
+
+        # PUT returns 204 so we need to make an extra GET query to return the latest values
+        self.make_request('put', url, data=data)
+        return self.get(service, guid)
 
     def create(self, service, data):
         url = "{base_url}/{service}Set".format(

--- a/crm-poc/apps/cdms_api/tests/utils.py
+++ b/crm-poc/apps/cdms_api/tests/utils.py
@@ -18,12 +18,27 @@ def mocked_cdms_get(modified_on=None, get_data={}):
     return internal
 
 
-def mocked_cdms_create(create_data={}):
+def mocked_cdms_create(modified_on=None, cdms_id='new cdms pk', create_data={}):
     def internal(service, data):
+        modified = modified_on or timezone.now()
         defaults = {
-            '{service}Id'.format(service=service): 'new cdms pk'
+            '{service}Id'.format(service=service): cdms_id,
+            'CreatedOn': datetime_to_cdms_datetime(modified),
+            'ModifiedOn': datetime_to_cdms_datetime(modified),
         }
         defaults.update(create_data)
+        return defaults
+    return internal
+
+
+def mocked_cdms_update(modified_on=None, update_data={}):
+    def internal(service, guid, data):
+        modified = modified_on or timezone.now()
+        defaults = {
+            'CreatedOn': datetime_to_cdms_datetime(modified),
+            'ModifiedOn': datetime_to_cdms_datetime(modified),
+        }
+        defaults.update(update_data)
         return defaults
     return internal
 
@@ -32,5 +47,6 @@ def get_mocked_api():
     api = mock.MagicMock(spec=CDMSApi)
 
     api.create.side_effect = mocked_cdms_create()
-    api.get.side_effect = mocked_cdms_get
+    api.get.side_effect = mocked_cdms_get()
+    api.update.side_effect = mocked_cdms_update()
     return api

--- a/crm-poc/apps/migrator/models.py
+++ b/crm-poc/apps/migrator/models.py
@@ -45,9 +45,47 @@ class CDMSModel(TimeStampedModel):
         return super(CDMSModel, self)._do_insert(manager, using, fields, update_pk, raw)
 
     def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update):
+        """
+        This method will try to update the model. If the model was updated (in
+        the sense that an update query was done and a matching row was found
+        from the DB) the method will return True.
+
+        NOTE: this is copy/paste from Django +
+        - cmd_skip if requested
+        - call to _update_with_modified instead of _update to make clear that it's a new method not the
+            django one
+        """
         if self._cdms_skip:
             base_qs = base_qs.skip_cdms()
-        return super(CDMSModel, self)._do_update(base_qs, using, pk_val, values, update_fields, forced_update)
+
+        filtered = base_qs.filter(pk=pk_val)
+        if not values:
+            # We can end up here when saving a model in inheritance chain where
+            # update_fields doesn't target any field in current model. In that
+            # case we just say the update succeeded. Another case ending up here
+            # is a model with just PK - in that case check that the PK still
+            # exists.
+            return update_fields is not None or filtered.exists()
+        if self._meta.select_on_save and not forced_update:
+            if filtered.exists():
+                # It may happen that the object is deleted from the DB right after
+                # this check, causing the subsequent UPDATE to return zero matching
+                # rows. The same result can occur in some rare cases when the
+                # database returns zero despite the UPDATE being executed
+                # successfully (a row is matched and updated). In order to
+                # distinguish these two cases, the object's existence in the
+                # database is again checked for if the UPDATE query returns 0.
+                n_records, modified = filtered._update_with_modified(values)
+                if modified:
+                    self.modified = modified
+                return n_records > 0 or filtered.exists()
+            else:
+                return False
+
+        n_records, modified = filtered._update_with_modified(values)
+        if modified:
+            self.modified = modified
+        return n_records > 0
 
     def _do_delete_cdms_obj(self):
         """

--- a/crm-poc/settings/base.py
+++ b/crm-poc/settings/base.py
@@ -116,7 +116,6 @@ TEMPLATES = [
 ]
 
 # CDMS SETTINGS
-CDMS_SYNC_DELTA = 2  # num of seconds after which the objects are considered out-of-sync
 CDMS_ADFS_URL = ''
 CDMS_BASE_URL = ''
 CDMS_USERNAME = ''


### PR DESCRIPTION
The old logic used two different values for local_obj.modified and cmds_obj.modifiedOn and checked that the delta between the two was small enough (`CDMS_SYNC_DELTA ` constant in settings) for the objs to be considered synchronized.

The new logic gets rid of the delta and updates the local_obj.modified with the value from cdms every time an operation happens.
In this way, we consider the two objs in sync if local_obj.modified == cdms_obj.modifiedOn.

Not as clean as I wanted, especially the update methods that I had to override but I believe it's a more robust solution to the previous one.