### PR TITLE
Implement order_by

### DIFF
--- a/crm-poc/apps/cdms_api/base.py
+++ b/crm-poc/apps/cdms_api/base.py
@@ -142,7 +142,7 @@ class CDMSApi(object):
 
         return resp
 
-    def list(self, service, top=50, skip=0, select=None, filters=None, orderby=None):
+    def list(self, service, top=50, skip=0, select=None, filters=None, order_by=None):
         params = {}
         if filters:
             params['$filter'] = ' and '.join(filters)
@@ -150,8 +150,10 @@ class CDMSApi(object):
         if select:
             params['$select'] = ','.join(select)
 
-        if orderby:
-            params['$orderby'] = orderby
+        if order_by:
+            if isinstance(order_by, str):
+                order_by = [order_by]
+            params['$orderby'] = ','.join(order_by)
 
         url = "{base_url}/{service}Set?$top={top}&$skip={skip}&{params}".format(
             base_url=self.CRM_REST_BASE_URL,

--- a/crm-poc/apps/migrator/cdms_migrator.py
+++ b/crm-poc/apps/migrator/cdms_migrator.py
@@ -1,4 +1,5 @@
 from cdms_api.utils import cdms_datetime_to_datetime
+from cdms_api import fields as cdms_fields
 
 from .exceptions import NotMappingFieldException, ObjectsNotInSyncException
 
@@ -6,6 +7,16 @@ from .exceptions import NotMappingFieldException, ObjectsNotInSyncException
 class BaseCDMSMigrator(object):
     fields = {}
     service = None
+
+    def __init__(self):
+        self.all_fields = self.build_filters()
+
+    def build_filters(self):
+        all_fields = {
+            'modified': cdms_fields.DateTimeField('ModifiedOn')
+        }
+        all_fields.update(self.fields)
+        return all_fields
 
     def get_cdms_pk(self, cdms_data):
         return cdms_data['{service}Id'.format(service=self.service)]
@@ -33,7 +44,7 @@ class BaseCDMSMigrator(object):
         return change_delta, cdms_modified_on, cdms_created_on
 
     def get_cdms_field(self, field_name):
-        cdms_field = self.fields.get(field_name)
+        cdms_field = self.all_fields.get(field_name)
         if not cdms_field:
             raise NotMappingFieldException(
                 'No mapping found for field {field}'.format(field=field_name)

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -85,6 +85,15 @@ class CDMSQuerySet(models.QuerySet):
         obj.save(force_insert=True, using=self.db, skip_cdms=self.cdms_skip)
         return obj
 
+    def order_by(self, *field_names):
+        ret = super(CDMSQuerySet, self).order_by(*field_names)
+
+        if not self.cdms_skip:
+            ret.cdms_query.clear_ordering()
+            ret.cdms_query.add_ordering(*field_names)
+
+        return ret
+
     def _filter_or_exclude(self, negate, *args, **kwargs):
         if not self.cdms_skip:
             if args or kwargs:

--- a/crm-poc/apps/migrator/tests/queries/base.py
+++ b/crm-poc/apps/migrator/tests/queries/base.py
@@ -57,6 +57,9 @@ class BaseMockedCDMSApiTestCase(TransactionTestCase):
         self.assertAPICalled(model, 'get', kwargs=kwargs, tot=tot)
 
     def assertAPIListCalled(self, model, kwargs, tot=1):
+        # 'ModifiedOn asc' is the default ordering so just add it to kwargs if not present
+        if 'order_by' not in kwargs:
+            kwargs['order_by'] = ['ModifiedOn asc']
         self.assertAPICalled(model, 'list', kwargs=kwargs, tot=tot)
 
     def assertAPIDeleteCalled(self, model, kwargs, tot=1):

--- a/crm-poc/apps/migrator/tests/queries/models.py
+++ b/crm-poc/apps/migrator/tests/queries/models.py
@@ -34,3 +34,6 @@ class SimpleObj(CDMSModel):
     objects = MigratorManager()
     django_objects = models.Manager()
     cdms_migrator = SimpleMigrator()
+
+    class Meta:
+        ordering = ['modified']

--- a/crm-poc/apps/migrator/tests/queries/test_order_by.py
+++ b/crm-poc/apps/migrator/tests/queries/test_order_by.py
@@ -5,13 +5,97 @@ from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 
 
 class OrderByTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: to be fixed')
-    def test_order_by_one_field(self):
-        pass
+    def test_order_by_default(self):
+        """
+        If order_by not specified, the default 'modified' field should be used.
+        """
+        list(SimpleObj.objects.all())
 
-    @skip('TODO: to be fixed')
+        self.assertAPIListCalled(
+            SimpleObj,
+            kwargs={
+                'filters': [],
+                'order_by': ['ModifiedOn asc']
+            }
+        )
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+
+    def test_order_by_name_asc(self):
+        """
+        Given the field 'myfield' mapped to the cdms field 'myCDMSfield':
+
+        Klass.objects.all().order_by('myfield') should make a cdms call ordered by 'myCDMSfield asc'.
+        """
+        list(SimpleObj.objects.all().order_by('name'))
+
+        self.assertAPIListCalled(
+            SimpleObj,
+            kwargs={
+                'filters': [],
+                'order_by': ['Name asc']
+            }
+        )
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+
+    def test_order_by_name_desc(self):
+        """
+        Given the field 'myfield' mapped to the cdms field 'myCDMSfield':
+
+        Klass.objects.all().order_by('-myfield') should order by 'myCDMSfield desc'.
+        """
+        list(SimpleObj.objects.all().order_by('-name'))
+
+        self.assertAPIListCalled(
+            SimpleObj,
+            kwargs={
+                'filters': [],
+                'order_by': ['Name desc']
+            }
+        )
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+
     def test_order_by_two_fields(self):
-        pass
+        """
+        Given the fields 'myfield1' and 'myfield2' mapped to the cdms fields 'myCDMSfield1' and 'myCDMSfield2':
+
+        Klass.objects.all().order_by('myfield1', '-myfield2') should make a cdms call
+        order by 'myCDMSfield1 asc AND myCDMSfield2 desc'.
+        """
+        list(SimpleObj.objects.all().order_by('modified', '-name'))
+
+        self.assertAPIListCalled(
+            SimpleObj,
+            kwargs={
+                'filters': [],
+                'order_by': ['ModifiedOn asc', 'Name desc']
+            }
+        )
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+
+    def test_order_by_non_cdms_field(self):
+        """
+        Ordering by a non-cdms field is not allowed as the cdms call to get the list would not be ordered by
+        the same field.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            list,
+            SimpleObj.objects.all().order_by('d_field')
+        )
+
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+
+    def test_order_randomly(self):
+        """
+        Klass.objects.all().order_by('?') not currently implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            list,
+            SimpleObj.objects.all().order_by('?')
+        )
+
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
 
     @skip('TODO: to be fixed')
     def test_order_by_related_obj_field(self):
@@ -19,37 +103,34 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
 
 
 class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
-    def test_order_by_one_field(self):
-        list(SimpleObj.objects.skip_cdms().order_by('name'))
+    def test_order_by_default(self):
+        """
+        Klass.objects.skip_cdms().all() should not hit cdms.
+        """
+        list(SimpleObj.objects.skip_cdms().all())
+        self.assertNoAPICalled()
+
+    def test_order_by_name(self):
+        """
+        Klass.objects.skip_cdms().all().order_by('field') should not hit cdms.
+        """
+        list(SimpleObj.objects.skip_cdms().all().order_by('name'))
         self.assertNoAPICalled()
 
     def test_order_by_two_fields(self):
-        list(SimpleObj.objects.skip_cdms().order_by('name', 'int_field'))
+        """
+        Klass.objects.skip_cdms().all().order_by('field1', '-field2') should not hit cdms.
+        """
+        list(SimpleObj.objects.skip_cdms().all().order_by('modified', '-name'))
+        self.assertNoAPICalled()
+
+    def test_order_randomly(self):
+        """
+        Klass.objects.skip_cdms().all().order_by('?') should not hit cdms.
+        """
+        list(SimpleObj.objects.skip_cdms().all().order_by('?'))
         self.assertNoAPICalled()
 
     @skip('TODO: to be fixed')
     def test_order_by_related_obj_field(self):
-        pass
-
-
-class OrderByExtraManagerTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: to be decided')
-    def test_order_by_one_field(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
-
-    @skip('TODO: to be decided')
-    def test_order_by_two_fields(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
-
-    @skip('TODO: to be decided')
-    def test_order_by_related_obj_field(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
         pass


### PR DESCRIPTION
- Klass.objects.all().order_by('...') makes a cdms call ordered by the cdms mapped field
- support for single, multiple field, asc and desc
- ordering by a non-cdms field is not allowed
- Klass.objects.skip_cdms().order_by('...') skips cdms calls

It's important that the Django model has a default ordering otherwise underlying cdms calls will not be ordered the same way as local ones.
A warning will be given if no default ordering is specified in Meta.