### PR TITLE
Make sure op AND, OR and NOT are covered

### DIFF
--- a/crm-poc/apps/cdms_api/base.py
+++ b/crm-poc/apps/cdms_api/base.py
@@ -145,7 +145,7 @@ class CDMSApi(object):
     def list(self, service, top=50, skip=0, select=None, filters=None, order_by=None):
         params = {}
         if filters:
-            params['$filter'] = ' and '.join(filters)
+            params['$filter'] = filters
 
         if select:
             params['$select'] = ','.join(select)

--- a/crm-poc/apps/migrator/lookups.py
+++ b/crm-poc/apps/migrator/lookups.py
@@ -1,0 +1,79 @@
+import datetime
+from numbers import Number
+
+from django.utils import tree
+
+from .models import CDMSModel
+
+
+class Lookup(object):
+    AND = 'AND'
+    OR = 'OR'
+    EXPRS = {
+        'exact': '{field} eq {value}',
+        'iexact': '{field} eq {value}',
+        'lt': '{field} lt {value}',
+        'lte': '{field} le {value}',
+        'gt': '{field} gt {value}',
+        'gte': '{field} ge {value}',
+        'contains': 'substringof({value}, {field})',
+        'icontains': 'substringof({value}, {field})',
+        'startswith': 'startswith({field}, {value})',
+        'istartswith': 'startswith({field}, tolower({value}))',
+        'endswith': 'endswith({field}, {value})',
+        'iendswith': 'endswith({field}, tolower({value}))',
+        'year': 'year({field}) eq {value}',
+        'month': 'month({field}) eq {value}',
+        'day': 'day({field}) eq {value}',
+        'hour': 'hour({field}) eq {value}',
+        'minute': 'minute({field}) eq {value}',
+        'second': 'second({field}) eq {value}',
+    }
+
+    def __init__(self, field, expr, value):
+        self.field = field
+        self.expr = expr
+        self.value = value
+
+    def convert_value(self, value):
+        if isinstance(value, Number):
+            return value
+        if isinstance(value, datetime.datetime):
+            return "datetime'{value}'".format(value=value.strftime("%Y-%m-%dT%H:%M:%S"))
+
+        if isinstance(value, CDMSModel):
+            return "guid'{value}'".format(value=value.cdms_pk)
+        return "'{value}'".format(value=value)
+
+    def as_filter_string(self):
+        cdms_expr = self.EXPRS.get(self.expr)
+        if not cdms_expr:
+            raise NotImplementedError('Expression %s not recognised yet' % self.expr)
+
+        return cdms_expr.format(field=self.field, value=self.convert_value(self.value))
+
+
+class FilterNode(tree.Node):
+    """
+    Node subclass which can be used to construct cdms filter queries.
+
+    Technically a tree with FilterNode as nodes and leaves as python objects with a `as_filter_string` method.
+
+    See tests for examples of how to use it.
+    """
+
+    def as_filter_string(self):
+        result = []
+        for child in self.children:
+            filter_string = child.as_filter_string()
+            if filter_string:
+                result.append(filter_string)
+        conn = ' %s ' % self.connector
+        filters_string = conn.lower().join(sorted(result))
+
+        if filters_string:
+            if self.negated:
+                filters_string = 'not (%s)' % filters_string
+            elif len(result) > 1:
+                filters_string = '(%s)' % filters_string
+        return filters_string

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -105,11 +105,6 @@ class CDMSQuerySet(models.QuerySet):
                     raise NotImplementedError(
                         'Cannot yet get all objects, not implemented yet'
                     )
-            else:
-                if self.query.has_filters():
-                    raise NotImplementedError(
-                        'Filter chaining not implemented yet, please combine your filters into one'
-                    )
 
             if not (len(kwargs.keys()) == 1 and list(kwargs)[0] in ('id', 'pk')):
                 clone = self._clone()

--- a/crm-poc/apps/migrator/tests/queries/test_filter_exclude.py
+++ b/crm-poc/apps/migrator/tests/queries/test_filter_exclude.py
@@ -1,4 +1,4 @@
-from unittest import skip
+import datetime
 
 from django.db.models import Q
 
@@ -11,7 +11,15 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'"]}
+            SimpleObj, kwargs={'filters': "Name eq 'something'"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_q_one_field(self):
+        list(SimpleObj.objects.filter(Q(name='something')))
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "Name eq 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -19,73 +27,140 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name='something', int_field=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'", "IntField eq 1"]}
+            SimpleObj, kwargs={'filters': "(IntField eq 1 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
-    @skip('TODO: to be fixed')
+    def test_q_two_fields_in_and(self):
+        list(SimpleObj.objects.filter(Q(name='something') & Q(int_field=10)))
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "(IntField eq 10 and Name eq 'something')"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
     def test_two_fields_in_chain(self):
         list(SimpleObj.objects.filter(name='something').filter(int_field=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'", "IntField eq 1"]}
+            SimpleObj, kwargs={'filters': "(IntField eq 1 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
-    @skip('TODO: to be fixed')
     def test_two_fields_in_or(self):
         list(SimpleObj.objects.filter(Q(name='something') | Q(int_field=1)))
 
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "(IntField eq 1 or Name eq 'something')"}
+        )
+
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_q_fields_in_and_in_group(self):
+        dt = datetime.datetime(2016, 1, 1).replace(tzinfo=datetime.timezone.utc)
+        list(
+            SimpleObj.objects.filter(
+                Q(Q(name='something') & Q(int_field=10)) & Q(dt_field__gt=dt)
+            )
+        )
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters':
+                    "(DateTimeField gt datetime'2016-01-01T00:00:00' and IntField eq 10 and Name eq 'something')"
+            }
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_q_fields_in_and__or_in_group(self):
+        dt = datetime.datetime(2016, 1, 1).replace(tzinfo=datetime.timezone.utc)
+        list(
+            SimpleObj.objects.filter(
+                Q(Q(name='something') | Q(int_field=10)) & Q(dt_field__gt=dt)
+            )
+        )
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters':
+                    "((IntField eq 10 or Name eq 'something') and DateTimeField gt datetime'2016-01-01T00:00:00')"
+            }
+        )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
 
 class FilterSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_filter(self):
+        """
+        Klass.objects.skip_cdms().filter(field=...) should not hit cdms.
+        """
         list(SimpleObj.objects.skip_cdms().filter(name='something'))
         self.assertNoAPICalled()
 
 
-class FilterWithExtraManagerTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO to be decided')
-    def test_filter(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass
-
-
 class ExcludeTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO: to be fixed')
     def test_one_field(self):
         list(SimpleObj.objects.exclude(name='something'))
 
-    @skip('TODO: to be fixed')
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "not (Name eq 'something')"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
     def test_two_fields(self):
         list(SimpleObj.objects.exclude(name='something', int_field=1))
 
-    @skip('TODO: to be fixed')
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "not (IntField eq 1 and Name eq 'something')"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
     def test_two_fields_in_chain(self):
         list(SimpleObj.objects.exclude(name='something').exclude(int_field=1))
 
-    @skip('TODO: to be fixed')
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "(not (IntField eq 1) and not (Name eq 'something'))"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
     def test_two_fields_in_or(self):
         list(SimpleObj.objects.exclude(Q(name='something') | Q(int_field=1)))
 
-    @skip('TODO: to be fixed')
-    def test_filter_exclude(self):
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "not ((IntField eq 1 or Name eq 'something'))"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_simple_filter_exclude(self):
         list(SimpleObj.objects.filter(name='something').exclude(int_field=1))
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={'filters': "(Name eq 'something' and not (IntField eq 1))"}
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_complex_filter_exclude(self):
+        list(
+            SimpleObj.objects.filter(
+                Q(name='something') | Q(name='something else')
+            ).exclude(
+                Q(int_field=1) | Q(int_field=2)
+            )
+        )
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters':
+                "((Name eq 'something else' or Name eq 'something') and not ((IntField eq 1 or IntField eq 2)))"
+            }
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
 
 class ExcludeSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
+    """
+    Klass.objects.skip_cdms().exclude(field=...) should not hit cdms.
+    """
     def test_exclude(self):
         list(SimpleObj.objects.skip_cdms().exclude(name='something'))
         self.assertNoAPICalled()
-
-
-class ExcludWithExtraManagerTestCase(BaseMockedCDMSApiTestCase):
-    @skip('TODO to be decided')
-    def test_exclude(self):
-        """
-        The output when using an extra manager at the moment is unexpected and should not be used.
-        """
-        pass

--- a/crm-poc/apps/migrator/tests/queries/test_filter_lookups.py
+++ b/crm-poc/apps/migrator/tests/queries/test_filter_lookups.py
@@ -1,4 +1,3 @@
-import datetime
 from unittest import skip
 
 from django.utils import timezone
@@ -18,7 +17,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__exact='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'"]}
+            SimpleObj, kwargs={'filters': "Name eq 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -26,7 +25,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__iexact='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'"]}
+            SimpleObj, kwargs={'filters': "Name eq 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -34,7 +33,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__contains='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["substringof('something', Name)"]}
+            SimpleObj, kwargs={'filters': "substringof('something', Name)"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -42,7 +41,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__icontains='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["substringof('something', Name)"]}
+            SimpleObj, kwargs={'filters': "substringof('something', Name)"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -57,7 +56,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__gt='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name gt 'something'"]}
+            SimpleObj, kwargs={'filters': "Name gt 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -65,7 +64,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__gte='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name ge 'something'"]}
+            SimpleObj, kwargs={'filters': "Name ge 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -73,7 +72,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__lt='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name lt 'something'"]}
+            SimpleObj, kwargs={'filters': "Name lt 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -81,7 +80,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__lte='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name le 'something'"]}
+            SimpleObj, kwargs={'filters': "Name le 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -89,7 +88,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__startswith='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["startswith(Name, 'something')"]}
+            SimpleObj, kwargs={'filters': "startswith(Name, 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -97,7 +96,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__istartswith='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["startswith(Name, tolower('something'))"]}
+            SimpleObj, kwargs={'filters': "startswith(Name, tolower('something'))"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -105,7 +104,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__endswith='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["endswith(Name, 'something')"]}
+            SimpleObj, kwargs={'filters': "endswith(Name, 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -113,7 +112,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(name__iendswith='something'))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["endswith(Name, tolower('something'))"]}
+            SimpleObj, kwargs={'filters': "endswith(Name, tolower('something'))"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -129,7 +128,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__year=2016))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["year(DateTimeField) eq 2016"]}
+            SimpleObj, kwargs={'filters': "year(DateTimeField) eq 2016"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -137,7 +136,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__month=12))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["month(DateTimeField) eq 12"]}
+            SimpleObj, kwargs={'filters': "month(DateTimeField) eq 12"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -145,7 +144,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__day=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["day(DateTimeField) eq 1"]}
+            SimpleObj, kwargs={'filters': "day(DateTimeField) eq 1"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -160,7 +159,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__hour=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["hour(DateTimeField) eq 1"]}
+            SimpleObj, kwargs={'filters': "hour(DateTimeField) eq 1"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -168,7 +167,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__minute=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["minute(DateTimeField) eq 1"]}
+            SimpleObj, kwargs={'filters': "minute(DateTimeField) eq 1"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -176,7 +175,7 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.filter(dt_field__second=1))
 
         self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["second(DateTimeField) eq 1"]}
+            SimpleObj, kwargs={'filters': "second(DateTimeField) eq 1"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
 
@@ -208,33 +207,3 @@ class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):
             list, SimpleObj.objects.filter(name__iregex=r'.*')
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
-
-
-class ValueLookupsTestCase(BaseMockedCDMSApiTestCase):
-    def setUp(self):
-        super(ValueLookupsTestCase, self).setUp()
-        self.obj = SimpleObj.objects.skip_cdms().create(
-            cdms_pk='cdms-pk', name='before something after'
-        )
-
-    def test_string(self):
-        list(SimpleObj.objects.filter(name__exact='something'))
-
-        self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["Name eq 'something'"]}
-        )
-
-    def test_datetime(self):
-        dt = datetime.datetime(day=28, month=2, year=2016).replace(tzinfo=datetime.timezone.utc)
-        list(SimpleObj.objects.filter(dt_field__exact=dt))
-
-        self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["DateTimeField eq datetime'2016-02-28T00:00:00'"]}
-        )
-
-    def test_int(self):
-        list(SimpleObj.objects.filter(int_field__exact=2))
-
-        self.assertAPIListCalled(
-            SimpleObj, kwargs={'filters': ["IntField eq 2"]}
-        )

--- a/crm-poc/apps/migrator/tests/queries/test_order_by.py
+++ b/crm-poc/apps/migrator/tests/queries/test_order_by.py
@@ -14,7 +14,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         self.assertAPIListCalled(
             SimpleObj,
             kwargs={
-                'filters': [],
+                'filters': '',
                 'order_by': ['ModifiedOn asc']
             }
         )
@@ -31,7 +31,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         self.assertAPIListCalled(
             SimpleObj,
             kwargs={
-                'filters': [],
+                'filters': '',
                 'order_by': ['Name asc']
             }
         )
@@ -48,7 +48,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         self.assertAPIListCalled(
             SimpleObj,
             kwargs={
-                'filters': [],
+                'filters': '',
                 'order_by': ['Name desc']
             }
         )
@@ -66,7 +66,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         self.assertAPIListCalled(
             SimpleObj,
             kwargs={
-                'filters': [],
+                'filters': '',
                 'order_by': ['ModifiedOn asc', 'Name desc']
             }
         )

--- a/crm-poc/apps/migrator/tests/test_lookups.py
+++ b/crm-poc/apps/migrator/tests/test_lookups.py
@@ -1,0 +1,123 @@
+import datetime
+
+from django.test.testcases import TestCase
+
+from migrator.lookups import FilterNode, Lookup
+
+
+class LookupTestCase(TestCase):
+    def test_simple(self):
+        """
+        Tests one single filter.
+        """
+        filters = FilterNode(
+            children=[
+                Lookup('Field', 'exact', 'my-field')
+            ]
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "Field eq 'my-field'"
+        )
+
+    def test_two_in_AND(self):
+        """
+        Tests two values in AND.
+        """
+        filters = FilterNode(
+            children=[
+                Lookup('Field1', 'exact', 'my-field1'),
+                Lookup('Field2', 'exact', 'my-field2')
+            ],
+            connector=Lookup.AND
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "(Field1 eq 'my-field1' and Field2 eq 'my-field2')"
+        )
+
+    def test_two_in_OR(self):
+        """
+        Tests two values in OR.
+        """
+        filters = FilterNode(
+            children=[
+                Lookup('Field1', 'exact', 'my-field1'),
+                Lookup('Field2', 'exact', 'my-field2')
+            ],
+            connector=Lookup.OR
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "(Field1 eq 'my-field1' or Field2 eq 'my-field2')"
+        )
+
+    def test_complex(self):
+        """
+        Tests multiple values in AND and OR.
+        """
+        filters = FilterNode(
+            children=[
+                FilterNode(
+                    children=[
+                        Lookup('Field2', 'exact', 'my-field2'),
+                        FilterNode(
+                            children=[
+                                Lookup('Field3', 'exact', 'my-field3')
+                            ],
+                            negated=True
+                        ),
+                    ],
+                    connector=Lookup.OR
+                ),
+                Lookup('Field1', 'exact', 'my-field1')
+            ],
+            connector=Lookup.AND
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "((Field2 eq 'my-field2' or not (Field3 eq 'my-field3')) and Field1 eq 'my-field1')"
+        )
+
+
+class ValueLookupTestCase(TestCase):
+    def test_string(self):
+        filters = FilterNode(
+            children=[
+                Lookup('Field', 'exact', 'my-field')
+            ]
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "Field eq 'my-field'"
+        )
+
+    def test_datetime(self):
+        dt = datetime.datetime(day=28, month=2, year=2016).replace(tzinfo=datetime.timezone.utc)
+        filters = FilterNode(
+            children=[
+                Lookup('Field', 'exact', dt)
+            ]
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "Field eq datetime'2016-02-28T00:00:00'"
+        )
+
+    def test_int(self):
+        filters = FilterNode(
+            children=[
+                Lookup('Field', 'exact', 2)
+            ]
+        )
+
+        self.assertEqual(
+            filters.as_filter_string(),
+            "Field eq 2"
+        )


### PR DESCRIPTION
Implemented/tested operations in sync with cdms:

- Klass.objects.filter(field=...)
- Klass.objects.filter(Q(field=...)
- Klass.objects.filter(field1=...).filter(field2=...)
- Klass.objects.filter(field1=..., field2=...)
- Klass.objects.filter(Q(field1=...) & Q(field2=...))
- Klass.objects.filter(Q(field1=...) | Q(field2=...))
- Klass.objects.exclude(field...)
- Klass.objects.exclude(Q(field1=...) & Q(field2=...))
- Klass.objects.exclude(Q(field1=...) | Q(field2=...))
- Klass.objects.filter(Q(field1=...) | Q(field2=...)).exclude(Q(field1=...) | Q(field2=...))

Also, calling .skip_cdms() before .filter() or .exclude()  will not hit the cdms.