### PR TITLE
Implement and test cdms sync ops with foreign keys

### DIFF
--- a/crm-poc/apps/cdms_api/fields.py
+++ b/crm-poc/apps/cdms_api/fields.py
@@ -1,3 +1,5 @@
+from django.apps import apps
+
 from .utils import datetime_to_cdms_datetime, cdms_datetime_to_datetime
 
 
@@ -41,3 +43,42 @@ class DateTimeField(BaseField):
         if not value:
             return value
         return cdms_datetime_to_datetime(value)
+
+
+class IdRefField(BaseField):
+    def to_cdms_value(self, value):
+        if not value:
+            return value
+        return {'Id': value}
+
+    def from_cdms_value(self, value):
+        if not value:
+            return value
+        return value['Id']
+
+
+class ForeignKeyField(IdRefField):
+    model_cdms_pk_field = 'cdms_pk'
+
+    def __init__(self, cdms_name, fk_model):
+        super(ForeignKeyField, self).__init__(cdms_name)
+        self.fk_model = fk_model
+
+    def get_model(self):
+        return apps.get_model(self.fk_model)
+
+    def to_cdms_value(self, value):
+        if not value:
+            return value
+        return super(ForeignKeyField, self).to_cdms_value(
+            getattr(value, self.model_cdms_pk_field)
+        )
+
+    def from_cdms_value(self, value):
+        if not value:
+            return value
+
+        cdms_pk = super(ForeignKeyField, self).from_cdms_value(value)
+        return self.get_model()(**{
+            self.model_cdms_pk_field: cdms_pk
+        })

--- a/crm-poc/apps/migrator/decorators.py
+++ b/crm-poc/apps/migrator/decorators.py
@@ -1,0 +1,9 @@
+def only_with_cdms_skip(func):
+    def wrapper(self, *args, **kwargs):
+        if not self.cdms_skip:
+            raise NotImplementedError(
+                '{method} not implemented yet'.format(method=func.__name__)
+            )
+
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/crm-poc/apps/migrator/fields.py
+++ b/crm-poc/apps/migrator/fields.py
@@ -4,20 +4,66 @@ from django.db.models.fields.related_descriptors import ReverseManyToOneDescript
     create_reverse_many_to_one_manager
 
 
+def create_reverse_cdms_many_to_one_manager(superclass, rel):
+    subclass = create_reverse_many_to_one_manager(
+        superclass, rel
+    )
+
+    class RelatedManager(subclass):
+        def __init__(self, *args, **kwargs):
+            super(RelatedManager, self).__init__(*args, **kwargs)
+            self.cdms_skip = False
+
+        def __call__(self, **kwargs):
+            # We use **kwargs rather than a kwarg argument to enforce the
+            # `manager='manager_name'` syntax.
+            manager = getattr(self.model, kwargs.pop('manager'))
+            manager_class = create_reverse_cdms_many_to_one_manager(manager.__class__, rel)
+            return manager_class(self.instance)
+        do_not_call_in_templates = True
+
+        def skip_cdms(self):
+            """
+            Needs to be redefined because of Django madness :-|
+            """
+            self.cdms_skip = True
+            return self
+
+        def get_queryset(self):
+            qs = super(RelatedManager, self).get_queryset()
+
+            qs.cdms_skip = self.cdms_skip
+            qs._cdms_known_related_objects = {self.field.name: {self.instance.cdms_pk: self.instance}}
+            return qs
+
+        def add(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def create(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def get_or_create(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def update_or_create(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def remove(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def clear(self, *args, **kwargs):
+            raise NotImplementedError()
+
+    return RelatedManager
+
+
 class ReverseManyToOneDescriptor(ReverseManyToOneDescriptor):
     @cached_property
     def related_manager_cls(self):
-        superclass = create_reverse_many_to_one_manager(
+        return create_reverse_cdms_many_to_one_manager(
             self.rel.related_model._default_manager.__class__,
             self.rel,
         )
-
-        class RelatedManager(superclass):
-            def get_queryset(self):
-                qs = super(RelatedManager, self).get_queryset()
-                qs._cdms_known_related_objects = {self.field.name: {self.instance.cdms_pk: self.instance}}
-                return qs
-        return RelatedManager
 
 
 class CDMSForeignKey(ForeignKey):

--- a/crm-poc/apps/migrator/managers.py
+++ b/crm-poc/apps/migrator/managers.py
@@ -5,19 +5,9 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from cdms_api.exceptions import CDMSNotFoundException
 
+from .decorators import only_with_cdms_skip
 from .query import CDMSQuery, CDMSModelIterable, RefreshQuery, \
     InsertQuery, UpdateQuery
-
-
-def only_with_cdms_skip(func):
-    def wrapper(self, *args, **kwargs):
-        if not self.cdms_skip:
-            raise NotImplementedError(
-                '{method} not implemented yet'.format(method=func.__name__)
-            )
-
-        return func(self, *args, **kwargs)
-    return wrapper
 
 
 class CDMSQuerySet(models.QuerySet):
@@ -226,9 +216,11 @@ class CDMSQuerySet(models.QuerySet):
     def select_related(self, *args, **kwargs):
         return super(CDMSQuerySet, self).select_related(*args, **kwargs)
 
-    @only_with_cdms_skip
     def prefetch_related(self, *args, **kwargs):
-        return super(CDMSQuerySet, self).prefetch_related(*args, **kwargs)
+        """
+        Technically possible to implement in cdms_skip mode but not as easy as I would have expected so not worth it.
+        """
+        raise NotImplementedError()
 
     @only_with_cdms_skip
     def extra(self, *args, **kwargs):

--- a/crm-poc/apps/migrator/query.py
+++ b/crm-poc/apps/migrator/query.py
@@ -267,6 +267,8 @@ class CDMSQuery(object):
                     )
 
                 if field.is_relation and len(names) > 1:
+                    # cdms doesn't like 'relatedField/Field' so much but it could potentially
+                    # be possible so investigate further if worth.
                     raise NotImplementedError(
                         'Only filtering by foreign key allowed at the moment'
                     )
@@ -332,6 +334,8 @@ class CDMSQuery(object):
         cdms_field = self.model.cdms_migrator.get_cdms_field(field_name)
 
         if field.is_relation:
+            if not isinstance(value, CDMSModel):
+                raise NotImplementedError('Please use an object as value of relation fields')
             cdms_field_name = '{field}/Id'.format(field=cdms_field.cdms_name)
         else:
             cdms_field_name = cdms_field.cdms_name

--- a/crm-poc/apps/migrator/tests/queries/models.py
+++ b/crm-poc/apps/migrator/tests/queries/models.py
@@ -5,9 +5,28 @@ from migrator.cdms_migrator import BaseCDMSMigrator
 
 from cdms_api import fields as cdms_fields
 
+from migrator.fields import CDMSForeignKey
+
 
 class MigratorManager(CDMSManager):
     use_for_related_fields = True
+
+
+class ParentObjMigrator(BaseCDMSMigrator):
+    fields = {
+        'name': cdms_fields.StringField('Name')
+    }
+    service = 'Parent'
+
+
+class ParentObj(CDMSModel):
+    name = models.CharField(max_length=250)
+
+    objects = MigratorManager()
+    cdms_migrator = ParentObjMigrator()
+
+    class Meta:
+        ordering = ['modified']
 
 
 class SimpleMigrator(BaseCDMSMigrator):
@@ -15,24 +34,20 @@ class SimpleMigrator(BaseCDMSMigrator):
         'name': cdms_fields.StringField('Name'),
         'dt_field': cdms_fields.DateTimeField('DateTimeField'),
         'int_field': cdms_fields.IntegerField('IntField'),
+        'fk_obj': cdms_fields.ForeignKeyField('FKField', 'migrator.tests.queries.ParentObj'),
     }
     service = 'Simple'
-
-
-class RelatedObj(models.Model):
-    pass
 
 
 class SimpleObj(CDMSModel):
     name = models.CharField(max_length=250)
     dt_field = models.DateTimeField(null=True)
     int_field = models.IntegerField(null=True)
+    fk_obj = CDMSForeignKey(ParentObj, null=True)
 
     d_field = models.DateField(null=True)
-    fk_obj = models.ForeignKey(RelatedObj, null=True)
 
     objects = MigratorManager()
-    django_objects = models.Manager()
     cdms_migrator = SimpleMigrator()
 
     class Meta:

--- a/crm-poc/apps/migrator/tests/queries/test_all.py
+++ b/crm-poc/apps/migrator/tests/queries/test_all.py
@@ -35,21 +35,24 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
                 'CreatedOn': (timezone.now() - datetime.timedelta(days=2)).replace(microsecond=0),
                 'ModifiedOn': (timezone.now() - datetime.timedelta(days=1)).replace(microsecond=0),
                 'DateTimeField': None,
-                'IntField': None
+                'IntField': None,
+                'FKField': None
             },
             {
                 'SimpleId': 'cdms-pk2',
                 'Name': 'name2',
                 'ModifiedOn': obj2.modified,
                 'DateTimeField': None,
-                'IntField': 20
+                'IntField': 20,
+                'FKField': None
             },
             {
                 'SimpleId': 'cdms-pk3',
                 'Name': 'name3',
                 'ModifiedOn': obj3.modified + datetime.timedelta(days=1),
                 'DateTimeField': None,
-                'IntField': 20
+                'IntField': 20,
+                'FKField': None
             },
         ]
         self.mocked_cdms_api.list.side_effect = mocked_cdms_list(

--- a/crm-poc/apps/migrator/tests/queries/test_create.py
+++ b/crm-poc/apps/migrator/tests/queries/test_create.py
@@ -39,7 +39,8 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
                 'data': {
                     'Name': 'simple obj',
                     'DateTimeField': '/Date(1451606400000)/',
-                    'IntField': 10
+                    'IntField': 10,
+                    'FKField': None
                 }
             }
         )
@@ -88,7 +89,14 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(obj.modified, modified_on)
 
         self.assertAPICreateCalled(
-            SimpleObj, kwargs={'data': {'Name': 'simple obj', 'DateTimeField': None, 'IntField': None}}
+            SimpleObj, kwargs={
+                'data': {
+                    'Name': 'simple obj',
+                    'DateTimeField': None,
+                    'IntField': None,
+                    'FKField': None
+                }
+            }
         )
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
 

--- a/crm-poc/apps/migrator/tests/queries/test_extras.py
+++ b/crm-poc/apps/migrator/tests/queries/test_extras.py
@@ -136,7 +136,10 @@ class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
         self.assertNoAPICalled()
 
     def test_skip_cdms(self):
-        SimpleObj.objects.skip_cdms().prefetch_related('fk_obj').get(pk=self.obj.pk)
+        self.assertRaises(
+            NotImplementedError,
+            SimpleObj.objects.skip_cdms().prefetch_related
+        )
         self.assertNoAPICalled()
 
 

--- a/crm-poc/apps/migrator/tests/queries/test_foreign_key.py
+++ b/crm-poc/apps/migrator/tests/queries/test_foreign_key.py
@@ -1,0 +1,374 @@
+from django.db.models import Q
+from django.utils import timezone
+
+from cdms_api.tests.utils import mocked_cdms_create
+
+from migrator.exceptions import NotMappingFieldException
+
+from migrator.tests.queries.models import SimpleObj, ParentObj
+from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+
+
+class BaseForeignKeyTestCase(BaseMockedCDMSApiTestCase):
+    def setUp(self):
+        super(BaseForeignKeyTestCase, self).setUp()
+        self.parent_obj = ParentObj.objects.skip_cdms().create(
+            cdms_pk='cdms-pk', name='name'
+        )
+
+
+class GetFromParentTestCase(BaseForeignKeyTestCase):
+    def test_all(self):
+        """
+        obj.child_set.all() should hit the cdms list endpoint and return all local children objs.
+        """
+        list(self.parent_obj.simpleobj_set.all())
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters': "FKField/Id eq guid'{0}'".format(self.parent_obj.cdms_pk)
+            }
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_filter_children(self):
+        """
+        obj.child_set.filter(Q(field=...) | Q(field=...)).exclude(Q(field=...) | Q(field=...))
+        should hit the cdms list endpoint and return all local children objs filtered by the django query specified.
+        """
+        list(
+            self.parent_obj.simpleobj_set.filter(
+                Q(name='name1') | Q(name='name2')
+            ).exclude(
+                Q(name='name3') | Q(name='name4')
+            )
+        )
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters':
+                    "((Name eq 'name1' or Name eq 'name2') "
+                    "and FKField/Id eq guid'{0}' "
+                    "and not ((Name eq 'name3' or Name eq 'name4')))".format(
+                        self.parent_obj.cdms_pk
+                    )
+            }
+        )
+        self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+
+    def test_filter_children_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().filter(Q(field=...) | Q(field=...)).exclude(Q(field=...) | Q(field=...))
+        should not hit cdms.
+        """
+        list(
+            self.parent_obj.simpleobj_set.skip_cdms().filter(
+                Q(name='name1') | Q(name='name2')
+            ).exclude(
+                Q(name='name3') | Q(name='name4')
+            )
+        )
+        self.assertNoAPICalled()
+
+    def test_filter_parent_by_children(self):
+        """
+        ParentClass.objects.filter(child_set__field=...) not implemented as not currently possible with cdms.
+        """
+        self.simple_obj = SimpleObj.objects.skip_cdms().create(
+            cdms_pk='simple-obj', fk_obj=self.parent_obj
+        )
+
+        self.assertRaises(
+            NotMappingFieldException,
+            ParentObj.objects.filter,
+            simpleobj=self.simple_obj
+        )
+        self.assertNoAPICalled()
+
+    def test_filter_parent_by_children_skip_cdms(self):
+        """
+        ParentClass.objects.skip_cdms().filter(related__name=...) should not hit cdms.
+        """
+        self.simple_obj = SimpleObj.objects.skip_cdms().create(
+            cdms_pk='simple-obj', fk_obj=self.parent_obj
+        )
+
+        list(ParentObj.objects.skip_cdms().filter(simpleobj=self.simple_obj))
+        self.assertNoAPICalled()
+
+
+class FilterByParentTestCase(BaseForeignKeyTestCase):
+    def test_filter_by_parent(self):
+        """
+        ChildClass.objects.filter(parent_fk=obj)
+
+        should filter by parent in cdms and then in local.
+        """
+        list(SimpleObj.objects.filter(fk_obj=self.parent_obj))
+
+        self.assertAPIListCalled(
+            SimpleObj, kwargs={
+                'filters': "FKField/Id eq guid'{0}'".format(self.parent_obj.cdms_pk)
+            }
+        )
+
+    def test_filter_by_parent_id(self):
+        """
+        ChildClass.objects.filter(parent_fk=obj.pk)
+
+        currently not implemented as we need the related object in order to get the `cdms_pk` field value.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            SimpleObj.objects.filter,
+            fk_obj=self.parent_obj.pk
+        )
+
+        self.assertNoAPICalled()
+
+    def test_filter_by_parent_field(self):
+        """
+        ChildClass.objects.filter(parent_fk__field=...)
+
+        currently not implemented as cdms doesn't like it too much.
+        NOTE: It could potentially be possible so investigate further if worth.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            SimpleObj.objects.filter,
+            fk_obj__name=self.parent_obj.name
+        )
+
+        self.assertNoAPICalled()
+
+    def test_filter_by_parent_field_skip_cdms(self):
+        """
+        Filtering after calling skip_cdms(), should not hit cdms.
+        """
+        list(SimpleObj.objects.skip_cdms().filter(fk_obj__name=self.parent_obj.name))
+        self.assertNoAPICalled()
+
+
+class GetParentFromChildTestCase(BaseForeignKeyTestCase):
+    def test_get(self):
+        """
+        obj.fk should hit cdms before querying the local db.
+        """
+        self.simple_obj = SimpleObj.objects.skip_cdms().create(
+            cdms_pk='simple-obj', fk_obj=self.parent_obj
+        )
+
+        obj = SimpleObj.objects.get(pk=self.simple_obj.pk)
+
+        self.assertAPIGetCalled(
+            SimpleObj, kwargs={'guid': self.simple_obj.cdms_pk}
+        )
+        self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+
+        self.mocked_cdms_api.reset_mock()
+
+        self.assertEqual(obj.fk_obj.pk, self.parent_obj.pk)
+        self.assertEqual(obj.fk_obj.name, self.parent_obj.name)
+
+        self.assertAPIGetCalled(
+            ParentObj, kwargs={'guid': self.parent_obj.cdms_pk}
+        )
+
+    def test_get_does_not_exist(self):
+        """
+        obj.fk should not hit cdms if the property is not set in local.
+        """
+        self.simple_obj = SimpleObj.objects.skip_cdms().create(
+            cdms_pk='simple-obj', fk_obj=None
+        )
+
+        obj = SimpleObj.objects.get(pk=self.simple_obj.pk)
+
+        self.assertAPIGetCalled(
+            SimpleObj, kwargs={'guid': self.simple_obj.cdms_pk}
+        )
+        self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+
+        self.mocked_cdms_api.reset_mock()
+
+        self.assertEqual(obj.fk_obj, None)
+
+        self.assertNoAPICalled()
+
+
+class CreateChildTestCase(BaseForeignKeyTestCase):
+    def test_create(self):
+        """
+        obj = ChildClass(parent_fk=...)
+        obj.save()
+
+        should create the object in local and in cdms with the related `parent_fk` set.
+        """
+        self.mocked_cdms_api.create.side_effect = mocked_cdms_create(
+            create_data={
+                'SimpleId': 'simple id',
+                'ModifiedOn': timezone.now()
+            }
+        )
+
+        obj = SimpleObj(
+            name='simple obj',
+            fk_obj=self.parent_obj
+        )
+        obj.save()
+        self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
+
+        self.assertAPICreateCalled(
+            SimpleObj, kwargs={
+                'data': {
+                    'Name': 'simple obj',
+                    'DateTimeField': None,
+                    'IntField': None,
+                    'FKField': {
+                        'Id': self.parent_obj.cdms_pk
+                    }
+                }
+            }
+        )
+        self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
+
+        # reload obj and check cdms_pk and modified
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
+        self.assertEqual(obj.fk_obj.cdms_pk, self.parent_obj.cdms_pk)
+
+    def test_create_skip_cdms(self):
+        """
+        obj = ChildClass(parent_fk=...)
+        obj.save(skip_cdms=True)
+
+        should not hit cdms.
+        """
+        obj = SimpleObj(
+            name='simple obj',
+            fk_obj=self.parent_obj
+        )
+        obj.save(skip_cdms=True)
+
+        self.assertNoAPICalled()
+
+
+class ExtraOpsFromParentTestCase(BaseForeignKeyTestCase):
+    def test_add(self):
+        """
+        obj.child_set.add(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.add, SimpleObj(name='name')
+        )
+
+    def test_add_skip_cdms(self):
+        """
+        obj.child_set.add(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().add, SimpleObj(name='name')
+        )
+
+    def test_create(self):
+        """
+        obj.child_set.create(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.create, name='name'
+        )
+
+    def test_create_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().create(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().create, name='name'
+        )
+
+    def test_get_or_create(self):
+        """
+        obj.child_set.get_or_create(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.get_or_create
+        )
+
+    def test_get_or_create_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().get_or_create(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().get_or_create
+        )
+
+    def test_update_or_create(self):
+        """
+        obj.child_set.update_or_create(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.update_or_create
+        )
+
+    def test_update_or_create_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().update_or_create(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().update_or_create
+        )
+
+    def test_remove(self):
+        """
+        obj.child_set.remove(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.remove
+        )
+
+    def test_remove_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().remove(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().remove
+        )
+
+    def test_clear(self):
+        """
+        obj.child_set.clear(...) currently not implemented.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.clear
+        )
+
+    def test_clear_skip_cdms(self):
+        """
+        obj.child_set.skip_cdms().clear(...) currently not implemented.
+        It's technically possible to implement but it would require a lot of effort
+        and it's not widely used so it's not worth it.
+        """
+        self.assertRaises(
+            NotImplementedError,
+            self.parent_obj.simpleobj_set.skip_cdms().clear
+        )

--- a/crm-poc/apps/migrator/tests/queries/test_get.py
+++ b/crm-poc/apps/migrator/tests/queries/test_get.py
@@ -71,7 +71,8 @@ class GetByCmdPKTestCase(BaseGetTestCase):
                 'ModifiedOn': modified_on,
                 'Name': 'new name',
                 'DateTimeField': None,
-                'IntField': None
+                'IntField': None,
+                'FKField': None
             }
         )
 
@@ -202,7 +203,8 @@ class SyncGetTestCase(BaseGetTestCase):
                 'ModifiedOn': modified_on,
                 'Name': 'new name',
                 'DateTimeField': '/Date(1451606400000)/',
-                'IntField': 10
+                'IntField': 10,
+                'FKField': None
             }
         )
 

--- a/crm-poc/apps/migrator/tests/queries/test_order_by.py
+++ b/crm-poc/apps/migrator/tests/queries/test_order_by.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from migrator.tests.queries.models import SimpleObj
 from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
 
@@ -97,9 +95,20 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
 
-    @skip('TODO: to be fixed')
     def test_order_by_related_obj_field(self):
-        pass
+        """
+        Klass.objects.all().order_by('fk_obj') should order by foreign key field.
+        """
+        list(SimpleObj.objects.all().order_by('fk_obj'))
+
+        self.assertAPIListCalled(
+            SimpleObj,
+            kwargs={
+                'filters': '',
+                'order_by': ['FKField asc']
+            }
+        )
+        self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
 
 
 class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
@@ -131,6 +140,6 @@ class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         list(SimpleObj.objects.skip_cdms().all().order_by('?'))
         self.assertNoAPICalled()
 
-    @skip('TODO: to be fixed')
     def test_order_by_related_obj_field(self):
-        pass
+        list(SimpleObj.objects.skip_cdms().all().order_by('fk_obj'))
+        self.assertNoAPICalled()

--- a/crm-poc/apps/migrator/tests/queries/test_update.py
+++ b/crm-poc/apps/migrator/tests/queries/test_update.py
@@ -58,7 +58,13 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj,
             kwargs={
                 'guid': 'cdms-pk',
-                'data': {'Name': 'simple obj', 'DateTimeField': None, 'IntField': None, 'SimpleId': 'cdms-pk'}
+                'data': {
+                    'Name': 'simple obj',
+                    'DateTimeField': None,
+                    'IntField': None,
+                    'SimpleId': 'cdms-pk',
+                    'FKField': None
+                }
             }
         )
         self.assertAPINotCalled(['list', 'create', 'delete'])

--- a/crm-poc/apps/organisation/cdms_migrator.py
+++ b/crm-poc/apps/organisation/cdms_migrator.py
@@ -1,41 +1,6 @@
-from django.apps import apps
-
 from cdms_api import fields as cdms_fields
 
 from migrator.cdms_migrator import BaseCDMSMigrator
-
-
-class IdRefField(cdms_fields.BaseField):
-    def to_cdms_value(self, value):
-        if not value:
-            return value
-        return {'Id': value}
-
-    def from_cdms_value(self, value):
-        if not value:
-            return value
-        return value['Id']
-
-
-class ObjectRefField(IdRefField):
-    def __init__(self, cdms_name, fk_model):
-        super(ObjectRefField, self).__init__(cdms_name)
-        self.fk_model = fk_model
-
-    def get_model(self):
-        return apps.get_model(self.fk_model)
-
-    def to_cdms_value(self, value):
-        if not value:
-            return value
-        return super(ObjectRefField, self).to_cdms_value(value.cdms_pk)
-
-    def from_cdms_value(self, value):
-        if not value:
-            return value
-
-        cdms_pk = super(ObjectRefField, self).from_cdms_value(value)
-        return self.get_model()(cdms_pk=cdms_pk)
 
 
 class OrganisationMigrator(BaseCDMSMigrator):
@@ -43,16 +8,16 @@ class OrganisationMigrator(BaseCDMSMigrator):
         'name': cdms_fields.StringField('Name'),
         'alias': cdms_fields.StringField('optevia_Alias'),
         'uk_organisation': cdms_fields.BooleanField('optevia_ukorganisation'),
-        'country': IdRefField('optevia_Country'),
+        'country': cdms_fields.IdRefField('optevia_Country'),
         'postcode': cdms_fields.StringField('optevia_PostCode'),
         'address1': cdms_fields.StringField('optevia_Address1'),
         'city': cdms_fields.StringField('optevia_TownCity'),
-        'uk_region': IdRefField('optevia_UKRegion'),
+        'uk_region': cdms_fields.IdRefField('optevia_UKRegion'),
         'country_code': cdms_fields.StringField('optevia_CountryCode'),
         'area_code': cdms_fields.StringField('optevia_AreaCode'),
         'phone_number': cdms_fields.StringField('optevia_TelephoneNumber'),
         'email_address': cdms_fields.StringField('EMailAddress1'),
-        'sector': IdRefField('optevia_Sector'),
+        'sector': cdms_fields.IdRefField('optevia_Sector'),
     }
     service = 'Account'
 
@@ -73,7 +38,7 @@ class ContactMigrator(BaseCDMSMigrator):
     fields = {
         'first_name': cdms_fields.StringField('FirstName'),
         'last_name': cdms_fields.StringField('LastName'),
-        'organisation': ObjectRefField(
+        'organisation': cdms_fields.ForeignKeyField(
             'ParentCustomerId',
             fk_model='organisation.Organisation'
         )


### PR DESCRIPTION
This implements sync cdms operations on foreign keys:

- `child_obj.parent_obj` will load the obj from cdms and local
- `parent_obj.child_set.all()` will get all the children of parent_obj
- `parent_obj.child_set.filter(...)` will filter children of parent_obj in cdms
- `ChildClass.objects.filter(parent_obj=...)` will filter by parent obj in cdms
- `obj = ChildClass(parent_obj=...); obj.save()` will save the relation in cdms

All other operations are not implemented, not even with skip_cdms()
- `parent_obj.child_set.add()`
- `parent_obj.child_set.create()`
- `parent_obj.child_set.get_or_create()`
- `parent_obj.child_set.update_or_create()`
- `parent_obj.child_set.remove()`
- `parent_obj.child_set.clear()`

skip_cdms implemented for:
- `parent_obj.child_set.skip_cdms().all()`
- `parent_obj.child_set.skip_cdms().filter()`
- `ChildClass.objects.skip_cdms().filter(parent_obj=...)`
- `obj = ChildClass(parent_obj=...); obj.save(cdms_skip=True)`